### PR TITLE
Add root AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+GigaAgent is a universal AI agent framework with a Python/FastAPI backend and React/Vite frontend. In local dev mode it uses SQLite (no external DB required).
+
+### Services
+
+| Service | Command | Port | Notes |
+|---------|---------|------|-------|
+| Backend (dev) | `cd backend && uv run giga_agent dev` | 9090 | Serves API + bundled frontend UI; uses SQLite in `.giga_agent/` |
+| Frontend (dev) | `cd front && npm run dev` | 3000 | Vite dev server; proxies `/api` to `localhost:9090` |
+
+### Running services
+
+1. Start the backend first — it runs migrations automatically on startup.
+2. The backend at `:9090` serves the built frontend bundle, so a separate frontend dev server is only needed when actively developing frontend code.
+3. Default login after first init: `admin@example.com` / `giga_agent_admin`.
+4. Sending a chat message will error unless at least one LLM connector is configured in Settings.
+
+### Lint / Test / Build
+
+See `backend/AGENTS.md` section 2 for full command reference. Quick summary:
+
+- **Backend lint:** `cd backend && uv run ruff check .`
+- **Backend format:** `cd backend && uv run ruff format .`
+- **Backend tests:** `cd backend && uv run pytest`
+- **Frontend format check:** `cd front && npm run format:check`
+- **Frontend build:** `cd front && npm run build`
+
+### Gotchas
+
+- The backend build hook (`backend/hatch_build.py`) requires the frontend bundle to exist at `front/dist` or `backend/giga_agent/ui_dist`. Build the frontend (`cd front && npm ci && npm run build`) before running `uv sync` in the backend directory.
+- The `uv` package manager must be installed (`curl -LsSf https://astral.sh/uv/install.sh | sh`); it is not part of the standard system packages.
+- Python 3.12 is required (see `backend/.python-version`).
+- Node.js 22 is required for the frontend.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a root-level `AGENTS.md` with Cursor Cloud specific instructions for developing in this codebase.

## What's included

- Overview of the GigaAgent product (Python/FastAPI backend + React/Vite frontend)
- Service table with commands, ports, and notes for backend and frontend dev servers
- Quick reference for lint/test/build commands (pointing to `backend/AGENTS.md` for full details)
- Key gotchas discovered during environment setup:
  - Frontend must be built before `uv sync` (hatch build hook dependency)
  - `uv` package manager installation requirement
  - Python 3.12 and Node.js 22 version requirements

## Environment verification

- Backend: `uv run pytest` — 470 tests passing
- Backend lint: `uv run ruff check .` — 53 pre-existing warnings (not introduced by this PR)
- Frontend: `npm run format:check` — all files pass Prettier check
- Frontend build: `npm run build` — successful
- Dev server: `uv run giga_agent dev` starts on port 9090, serves UI, login works with default credentials
- Frontend dev server: `npm run dev` starts Vite on port 3000 with API proxy to backend

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-437895c9-15c8-4c95-a1c4-74d57ea66ce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-437895c9-15c8-4c95-a1c4-74d57ea66ce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

