### PR TITLE
feat(rag): add Markdown (.md) file upload support

### DIFF
--- a/backend/giga_agent/modules/rag/services/document_processor.py
+++ b/backend/giga_agent/modules/rag/services/document_processor.py
@@ -1,3 +1,4 @@
+import mimetypes
 import uuid
 
 from fastapi import UploadFile
@@ -16,6 +17,8 @@ logger = get_logger(__name__)
 HANDLERS = {
     "application/pdf": PDFMinerParser(),
     "text/plain": TextParser(),
+    "text/markdown": TextParser(),
+    "text/x-markdown": TextParser(),
     "text/html": BS4HTMLParser(),
     "application/msword": MsWordParser(),
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
@@ -56,7 +59,12 @@ async def process_document(
         file_uuid = file_id if isinstance(file_id, uuid.UUID) else uuid.UUID(str(file_id))
 
     contents = await file.read()
-    blob = Blob(data=contents, mimetype=file.content_type or "text/plain")
+    content_type = file.content_type
+    if not content_type or content_type == "application/octet-stream":
+        guessed, _ = mimetypes.guess_type(file.filename or "")
+        if guessed:
+            content_type = guessed
+    blob = Blob(data=contents, mimetype=content_type or "text/plain")
 
     docs = MIMETYPE_BASED_PARSER.parse(blob)
     full_text = "\n\n".join((d.page_content or "") for d in docs).strip()

--- a/backend/tests/modules/test_rag_document_processor.py
+++ b/backend/tests/modules/test_rag_document_processor.py
@@ -1,6 +1,6 @@
 import unittest
 
-from giga_agent.modules.rag.services.document_processor import process_document
+from giga_agent.modules.rag.services.document_processor import SUPPORTED_MIMETYPES, process_document
 
 
 class _DummyUploadFile:
@@ -44,4 +44,36 @@ class RagDocumentProcessorTests(unittest.IsolatedAsyncioTestCase):
             self.assertGreater(end, start)
             self.assertLessEqual(end, len(full_text))
             self.assertEqual(full_text[start:end], d.page_content)
+
+    async def test_process_markdown_document(self) -> None:
+        md_text = "# Заголовок\n\nТекст параграфа с **жирным** и *курсивом*.\n\n- Пункт 1\n- Пункт 2\n"
+        dummy = _DummyUploadFile(
+            filename="readme.md",
+            content_type="text/markdown",
+            content=md_text.encode("utf-8"),
+        )
+
+        file_id, full_text, docs = await process_document(dummy)
+
+        self.assertTrue(file_id)
+        self.assertEqual(full_text, md_text.strip())
+        self.assertGreater(len(docs), 0)
+
+    async def test_process_markdown_with_octet_stream_fallback(self) -> None:
+        md_text = "# Test\n\nContent here.\n"
+        dummy = _DummyUploadFile(
+            filename="notes.md",
+            content_type="application/octet-stream",
+            content=md_text.encode("utf-8"),
+        )
+
+        file_id, full_text, docs = await process_document(dummy)
+
+        self.assertTrue(file_id)
+        self.assertEqual(full_text, md_text.strip())
+        self.assertGreater(len(docs), 0)
+
+    def test_markdown_mimetypes_in_supported_list(self) -> None:
+        self.assertIn("text/markdown", SUPPORTED_MIMETYPES)
+        self.assertIn("text/x-markdown", SUPPORTED_MIMETYPES)
 


### PR DESCRIPTION
## Summary

Closes #60

Adds support for uploading `.md` (Markdown) files to RAG collections.

## Changes

**`document_processor.py`:**
- Add `text/markdown` and `text/x-markdown` MIME types to `HANDLERS` using the existing `TextParser` — Markdown is plain text, no new dependencies needed
- Add extension-based MIME type guessing via `mimetypes.guess_type()` as fallback when the client sends `application/octet-stream` (common for `.md` files in browser uploads)

**`test_rag_document_processor.py`:**
- Test: Markdown file with explicit `text/markdown` content type is parsed correctly
- Test: Markdown file with `application/octet-stream` falls back to extension-based detection
- Test: Both markdown MIME types are present in `SUPPORTED_MIMETYPES`

## Details

Markdown files are semantically plain text with formatting markers. Using `TextParser` (same as `text/plain`) preserves the full content including headers, lists, and emphasis markers — which is ideal for RAG search since these markers provide useful semantic context.

The `mimetypes.guess_type()` fallback benefits all file types, not just Markdown — if a client sends `application/octet-stream` for a `.pdf` or `.docx`, the correct parser will now be selected automatically.

## Test plan

- [x] 3 new unit tests added
- [ ] Manual: upload a `.md` file via API/UI → verify it appears in document list and RAG search returns relevant results

🤖 Generated with [Claude Code](https://claude.com/claude-code)