### PR TITLE
fix(ui): replace hardcoded E2B placeholder with generic text

### DIFF
--- a/front/src/components/settings-page/sandbox.tsx
+++ b/front/src/components/settings-page/sandbox.tsx
@@ -607,7 +607,7 @@ export const SandboxSettings: React.FC = () => {
             </Label>
             <Input
               id="provider-name"
-              placeholder="Мой E2B провайдер"
+              placeholder="Название провайдера"
               value={providerName}
               onChange={(e) => setProviderName(e.target.value)}
               disabled={saving}


### PR DESCRIPTION
## Summary

The provider name input always showed "Мой E2B провайдер" as placeholder, regardless of selected provider type (local_docker, daytona, modal). Replaced with generic "Название провайдера".

## Changes

- `front/src/components/settings-page/sandbox.tsx` — one line: static placeholder text

Fixes #68