### PR TITLE
fix: prevent GIGACHAT_* env vars from overriding explicit connector settings

### DIFF
--- a/backend/giga_agent/connectors/gigachat.py
+++ b/backend/giga_agent/connectors/gigachat.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+from contextlib import contextmanager
 from typing import Any
 
 from gigachat.settings import AUTH_URL as GIGACHAT_DEFAULT_AUTH_URL
@@ -12,6 +14,36 @@ from pydantic import AliasChoices, Field
 from giga_agent.conf import get_settings
 from giga_agent.connectors.base import BaseConnector
 from giga_agent.connectors.registry import ConnectorRegistry
+
+# GigaChat SDK reads these env vars via pydantic BaseSettings.
+# When explicit settings are provided, we must suppress env vars
+# to prevent them from overriding the configured auth method.
+_GIGACHAT_ENV_KEYS = (
+    "GIGACHAT_CREDENTIALS",
+    "GIGACHAT_ACCESS_TOKEN",
+    "GIGACHAT_USER",
+    "GIGACHAT_PASSWORD",
+    "GIGACHAT_BASE_URL",
+    "GIGACHAT_AUTH_URL",
+    "GIGACHAT_SCOPE",
+    "GIGACHAT_CERT_FILE",
+    "GIGACHAT_KEY_FILE",
+    "GIGACHAT_KEY_FILE_PASSWORD",
+)
+
+
+@contextmanager
+def _suppress_gigachat_env():
+    """Temporarily remove GIGACHAT_* env vars so SDK doesn't pick them up."""
+    saved = {}
+    for key in _GIGACHAT_ENV_KEYS:
+        val = os.environ.pop(key, None)
+        if val is not None:
+            saved[key] = val
+    try:
+        yield
+    finally:
+        os.environ.update(saved)
 
 
 @ConnectorRegistry.register("gigachat")
@@ -128,7 +160,10 @@ class GigaChatConnector(BaseConnector):
         kwargs = self.get_connection_kwargs()
         if kwargs is None:
             raise ValueError("Invalid connection settings for connector type 'gigachat'")
-        return GigaChat(model="GigaChat", **kwargs)
+        if self._is_from_env_mode():
+            return GigaChat(model="GigaChat", **kwargs)
+        with _suppress_gigachat_env():
+            return GigaChat(model="GigaChat", **kwargs)
 
     async def check_connection(self) -> bool:
         if self._is_from_env_mode():
@@ -140,6 +175,7 @@ class GigaChatConnector(BaseConnector):
         if kwargs is None:
             raise ValueError("Invalid connection settings for connector type 'gigachat'")
 
-        llm = GigaChat(**kwargs)
+        with _suppress_gigachat_env():
+            llm = GigaChat(**kwargs)
         await llm.aget_models()
         return True

--- a/backend/tests/connectors/test_registry.py
+++ b/backend/tests/connectors/test_registry.py
@@ -147,6 +147,66 @@ class ConnectorRegistryTests(unittest.IsolatedAsyncioTestCase):
         mocked_llm.assert_called_once_with(verify_ssl_certs=False)
         mock_llm.aget_models.assert_awaited_once()
 
+    async def test_gigachat_explicit_settings_ignore_env_credentials(self):
+        """Explicit dev settings must not be overridden by GIGACHAT_* env vars."""
+        with patch.dict(
+            os.environ,
+            {
+                "GIGA_AGENT_GIGACHAT_FROM_ENV": "1",
+                "GIGACHAT_CREDENTIALS": "env-creds-should-be-ignored",
+            },
+            clear=True,
+        ):
+            reset_settings_cache()
+            connector = GigaChatConnector(
+                gigachat_api_type="dev",
+                gigachat_username="myuser",
+                gigachat_password="mypass",
+                gigachat_base_url="https://dev.example.com",
+            )
+            mock_llm = AsyncMock()
+            mock_llm.aget_models = AsyncMock(return_value=[])
+            with patch(
+                "giga_agent.connectors.gigachat.GigaChat",
+                return_value=mock_llm,
+            ) as mocked_llm:
+                result = await connector.check_connection()
+
+        self.assertTrue(result)
+        call_kwargs = mocked_llm.call_args[1]
+        self.assertEqual(call_kwargs["user"], "myuser")
+        self.assertEqual(call_kwargs["password"], "mypass")
+        self.assertEqual(call_kwargs["base_url"], "https://dev.example.com")
+        # credentials must NOT appear in kwargs (env var suppressed)
+        self.assertNotIn("credentials", call_kwargs)
+
+    async def test_gigachat_explicit_prod_settings_ignore_env_credentials(self):
+        """Explicit prod credentials must not be mixed with env vars."""
+        with patch.dict(
+            os.environ,
+            {
+                "GIGA_AGENT_GIGACHAT_FROM_ENV": "1",
+                "GIGACHAT_CREDENTIALS": "env-creds-should-be-ignored",
+                "GIGACHAT_USER": "env-user",
+            },
+            clear=True,
+        ):
+            reset_settings_cache()
+            connector = GigaChatConnector(
+                gigachat_api_type="prod",
+                gigachat_credentials="my-explicit-token",
+            )
+            mock_llm = Mock()
+            with patch(
+                "giga_agent.connectors.gigachat.GigaChat",
+                return_value=mock_llm,
+            ) as mocked_llm:
+                result = connector.get_api_object()
+
+        self.assertIs(result, mock_llm)
+        call_kwargs = mocked_llm.call_args[1]
+        self.assertEqual(call_kwargs["credentials"], "my-explicit-token")
+
     async def test_tavily_env_fallback(self):
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-env"}, clear=True):
             settings = await ConnectorRegistry.validate_settings("tavily", {})


### PR DESCRIPTION
## Summary

Fixes #78 — when `GIGA_AGENT_GIGACHAT_FROM_ENV=true` and `GIGACHAT_CREDENTIALS` is set in the environment, the GigaChat SDK (`pydantic BaseSettings`) picks up env vars even when explicit credentials are provided via connector settings. This breaks login/password (dev) and certificate auth.

**Root cause:** GigaChat SDK's `Settings(BaseSettings)` reads `GIGACHAT_*` env vars for any field not explicitly passed. The SDK constructor [filters out `None` values](https://github.com/ai-forever/gigachat/blob/main/src/gigachat/client.py) before creating `Settings`, so passing `credentials=None` does not override the env var.

**Fix:** Temporarily suppress `GIGACHAT_*` env vars when creating `GigaChat` client in non-env mode via a context manager, so only explicitly provided settings are used.

## Changes

- `gigachat.py`: Add `_suppress_gigachat_env()` context manager, wrap `GigaChat()` calls in `get_api_object()` and `check_connection()` for non-env mode
- `test_registry.py`: Add 2 tests — explicit dev and prod settings must not be overridden by env vars

## Notes

The issue also mentions certificate auth (`cert_file`). The current connector doesn't expose a certificate auth type — happy to add it in a follow-up if needed.