### PR TITLE
frontend: voice input, thread indicators, drag&drop, scroll button

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,20 @@ GigaAgent умеет:
 
 ## Быстрый старт
 
-1. Установите пакет:
-  ```bash
-   uv add giga_agent
+1. Соберите фронтенд:
+  ```
+   cd front && npm ci && npm run build && cd ..
+  ```
+2. Установите пакет и запустите dev-сервер:
+  ```
+   cd backend
+   uv run giga_agent dev
   ```
   Для локального sandbox через Jupyter установите optional extra:
   ```bash
    pip install -U "giga-agent[jupyter]"
   ```
-2. Запустите dev-сервер:
-  ```bash
-   uv run giga_agent dev
-  ```
-3. Откройте в браузере:
+4. Откройте в браузере:
   ```text
    http://localhost:9090
   ```

--- a/README.md
+++ b/README.md
@@ -61,20 +61,19 @@ GigaAgent умеет:
 
 ## Быстрый старт
 
-1. Соберите фронтенд:
-  ```
-   cd front && npm ci && npm run build && cd ..
-  ```
-2. Установите пакет и запустите dev-сервер:
-  ```
-   cd backend
-   uv run giga_agent dev
+1. Установите пакет:
+  ```bash
+   uv add giga_agent
   ```
   Для локального sandbox через Jupyter установите optional extra:
   ```bash
    pip install -U "giga-agent[jupyter]"
   ```
-4. Откройте в браузере:
+2. Запустите dev-сервер:
+  ```bash
+   uv run giga_agent dev
+  ```
+3. Откройте в браузере:
   ```text
    http://localhost:9090
   ```

--- a/backend/giga_agent/conf.py
+++ b/backend/giga_agent/conf.py
@@ -52,7 +52,6 @@ class Settings(BaseSettings):
         False, alias="GIGA_AGENT_SKIP_STARTUP_MIGRATIONS"
     )
     giga_agent_skip_onboarding: bool = Field(False, alias="GIGA_AGENT_SKIP_ONBOARDING")
-    giga_agent_stt_enabled: bool = Field(False, alias="GIGA_AGENT_STT_ENABLED")
     giga_agent_stt_runtime: str = Field("salute", alias="GIGA_AGENT_STT_RUNTIME")
     giga_agent_startup_migrations_lock_key: str = Field(
         "startup:migrations:lock",
@@ -370,7 +369,6 @@ def get_local_docker_max_active_sandboxes_from_env() -> int | None:
 
 GIGA_AGENT_PREFIX_API = get_settings().giga_agent_prefix_api
 GIGA_PREFIX_API = GIGA_AGENT_PREFIX_API
-GIGA_AGENT_STT_ENABLED = get_settings().giga_agent_stt_enabled
 GIGA_AGENT_STT_RUNTIME = get_settings().giga_agent_stt_runtime
 GIGA_AGENT_BASE_URL = get_settings().giga_agent_base_url
 GIGA_AGENT_FRONTEND_DIR = get_settings().giga_agent_frontend_dir

--- a/backend/giga_agent/conf.py
+++ b/backend/giga_agent/conf.py
@@ -52,6 +52,8 @@ class Settings(BaseSettings):
         False, alias="GIGA_AGENT_SKIP_STARTUP_MIGRATIONS"
     )
     giga_agent_skip_onboarding: bool = Field(False, alias="GIGA_AGENT_SKIP_ONBOARDING")
+    giga_agent_stt_enabled: bool = Field(False, alias="GIGA_AGENT_STT_ENABLED")
+    giga_agent_stt_runtime: str = Field("salute", alias="GIGA_AGENT_STT_RUNTIME")
     giga_agent_startup_migrations_lock_key: str = Field(
         "startup:migrations:lock",
         alias="GIGA_AGENT_STARTUP_MIGRATIONS_LOCK_KEY",
@@ -368,6 +370,8 @@ def get_local_docker_max_active_sandboxes_from_env() -> int | None:
 
 GIGA_AGENT_PREFIX_API = get_settings().giga_agent_prefix_api
 GIGA_PREFIX_API = GIGA_AGENT_PREFIX_API
+GIGA_AGENT_STT_ENABLED = get_settings().giga_agent_stt_enabled
+GIGA_AGENT_STT_RUNTIME = get_settings().giga_agent_stt_runtime
 GIGA_AGENT_BASE_URL = get_settings().giga_agent_base_url
 GIGA_AGENT_FRONTEND_DIR = get_settings().giga_agent_frontend_dir
 GIGA_AGENT_UI = get_settings().giga_agent_ui

--- a/backend/giga_agent/routes/__init__.py
+++ b/backend/giga_agent/routes/__init__.py
@@ -16,6 +16,7 @@ from giga_agent.routes.llms import router as llms_router
 from giga_agent.routes.resource_permissions import router as resource_permissions_router
 from giga_agent.routes.sandboxes import router as sandboxes_router
 from giga_agent.routes.search_engines import router as search_engines_router
+from giga_agent.routes.stt import router as stt_router
 
 router = APIRouter(prefix=GIGA_AGENT_PREFIX_API)
 router.include_router(agent_router)
@@ -29,6 +30,7 @@ router.include_router(generators_router)
 router.include_router(search_engines_router)
 router.include_router(groups_router)
 router.include_router(resource_permissions_router)
+router.include_router(stt_router)
 
 __all__ = [
     "router",
@@ -43,4 +45,5 @@ __all__ = [
     "search_engines_router",
     "groups_router",
     "resource_permissions_router",
+    "stt_router",
 ]

--- a/backend/giga_agent/routes/stt.py
+++ b/backend/giga_agent/routes/stt.py
@@ -1,0 +1,179 @@
+"""Speech-to-text route backed by Sber SaluteSpeech /speech:recognize."""
+
+from __future__ import annotations
+
+import io
+import os
+import uuid
+from typing import Annotated
+
+import aiohttp
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from pydantic import BaseModel
+from pydub import AudioSegment
+
+from giga_agent.models.users import User
+from giga_agent.modules.auth.api import get_current_active_user
+
+router = APIRouter(prefix="/stt", tags=["stt"])
+
+SALUTE_SPEECH_OAUTH_URL = "https://ngw.devices.sberbank.ru:9443/api/v2/oauth"
+SALUTE_SPEECH_RECOGNIZE_URL = "https://smartspeech.sber.ru/rest/v1/speech:recognize"
+
+# SaluteSpeech accepts audio/x-pcm;bit=16;rate=16000 natively. Browsers record
+# WebM/Opus, so we transcode to 16 kHz mono PCM16 on the way through.
+PCM_SAMPLE_RATE = 16000
+PCM_CHANNELS = 1
+PCM_SAMPLE_WIDTH = 2  # 16-bit
+
+
+class RecognizeResponse(BaseModel):
+    text: str
+
+
+def _transcode_to_pcm16(data: bytes) -> bytes:
+    audio = AudioSegment.from_file(io.BytesIO(data))
+    audio = (
+        audio.set_frame_rate(PCM_SAMPLE_RATE)
+        .set_channels(PCM_CHANNELS)
+        .set_sample_width(PCM_SAMPLE_WIDTH)
+    )
+    return audio.raw_data
+
+
+async def _fetch_salute_token(auth_token: str, scope: str) -> str:
+    """Fetch an access token; raises HTTPException with a distinguishable cause."""
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "RqUID": str(uuid.uuid4()),
+        "Authorization": f"Basic {auth_token}",
+    }
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(
+                SALUTE_SPEECH_OAUTH_URL,
+                headers=headers,
+                data={"scope": scope},
+                ssl=False,
+                timeout=30,
+            ) as response,
+        ):
+            body_text = await response.text()
+            if response.status == 401 or response.status == 403:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=(
+                        f"SaluteSpeech rejected credentials (HTTP {response.status}). "
+                        f"Check SALUTE_SPEECH / SALUTE_SCOPE. Body: {body_text[:200]}"
+                    ),
+                )
+            if response.status >= 400:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=(
+                        f"SaluteSpeech OAuth error (HTTP {response.status}): "
+                        f"{body_text[:200]}"
+                    ),
+                )
+            try:
+                body = await response.json(content_type=None)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"SaluteSpeech OAuth returned non-JSON: {body_text[:200]}",
+                ) from exc
+            token = body.get("access_token") if isinstance(body, dict) else None
+            if not token:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="SaluteSpeech OAuth response lacked access_token",
+                )
+            return token
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="SaluteSpeech OAuth request timed out",
+        ) from exc
+    except aiohttp.ClientError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"SaluteSpeech OAuth transport error: {exc}",
+        ) from exc
+
+
+@router.post("/recognize", response_model=RecognizeResponse)
+async def recognize_speech(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    audio: UploadFile = File(...),
+) -> RecognizeResponse:
+    auth_token = os.environ.get("SALUTE_SPEECH")
+    if not auth_token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="SALUTE_SPEECH credential is not configured",
+        )
+
+    raw = await audio.read()
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Empty audio payload",
+        )
+
+    try:
+        pcm = _transcode_to_pcm16(raw)
+    except Exception as exc:  # pydub wraps ffmpeg, swallow its specifics
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unsupported audio payload: {exc}",
+        ) from exc
+
+    scope = os.environ.get("SALUTE_SCOPE", "SALUTE_SPEECH_PERS")
+    token = await _fetch_salute_token(auth_token=auth_token, scope=scope)
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": f"audio/x-pcm;bit=16;rate={PCM_SAMPLE_RATE}",
+    }
+    params = {"language": "ru-RU"}
+
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(
+                SALUTE_SPEECH_RECOGNIZE_URL,
+                headers=headers,
+                params=params,
+                data=pcm,
+                ssl=False,
+                timeout=60,
+            ) as response,
+        ):
+            if response.status >= 400:
+                body = await response.text()
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"SaluteSpeech error {response.status}: {body}",
+                )
+            body = await response.json()
+    except aiohttp.ClientError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"SaluteSpeech transport error: {exc}",
+        ) from exc
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="SaluteSpeech request timed out",
+        ) from exc
+
+    # SaluteSpeech returns {"status": 200, "result": ["transcribed text", ...]}
+    parts = body.get("result") if isinstance(body, dict) else None
+    if not isinstance(parts, list):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Unexpected SaluteSpeech response shape",
+        )
+    text = " ".join(p for p in parts if isinstance(p, str)).strip()
+    return RecognizeResponse(text=text)

--- a/backend/giga_agent/routes/stt.py
+++ b/backend/giga_agent/routes/stt.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel
 from pydub import AudioSegment
 
+from giga_agent.conf import GIGA_AGENT_STT_ENABLED, GIGA_AGENT_STT_RUNTIME
 from giga_agent.models.users import User
 from giga_agent.modules.auth.api import get_current_active_user
 
@@ -107,6 +108,16 @@ async def recognize_speech(
     current_user: Annotated[User, Depends(get_current_active_user)],
     audio: UploadFile = File(...),
 ) -> RecognizeResponse:
+    if not GIGA_AGENT_STT_ENABLED:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="STT is disabled (set GIGA_AGENT_STT_ENABLED=1)",
+        )
+    if (GIGA_AGENT_STT_RUNTIME or "").strip().lower() != "salute":
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Unsupported STT runtime '{GIGA_AGENT_STT_RUNTIME}'",
+        )
     auth_token = os.environ.get("SALUTE_SPEECH")
     if not auth_token:
         raise HTTPException(

--- a/backend/giga_agent/routes/stt.py
+++ b/backend/giga_agent/routes/stt.py
@@ -2,17 +2,20 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
+import json
 import os
 import uuid
 from typing import Annotated
 
 import aiohttp
+from cashews import cache
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel
 from pydub import AudioSegment
 
-from giga_agent.conf import GIGA_AGENT_STT_ENABLED, GIGA_AGENT_STT_RUNTIME
+from giga_agent.conf import GIGA_AGENT_STT_RUNTIME
 from giga_agent.models.users import User
 from giga_agent.modules.auth.api import get_current_active_user
 
@@ -26,6 +29,7 @@ SALUTE_SPEECH_RECOGNIZE_URL = "https://smartspeech.sber.ru/rest/v1/speech:recogn
 PCM_SAMPLE_RATE = 16000
 PCM_CHANNELS = 1
 PCM_SAMPLE_WIDTH = 2  # 16-bit
+SALUTE_TOKEN_CACHE_TTL = "10m"
 
 
 class RecognizeResponse(BaseModel):
@@ -40,6 +44,16 @@ def _transcode_to_pcm16(data: bytes) -> bytes:
         .set_sample_width(PCM_SAMPLE_WIDTH)
     )
     return audio.raw_data
+
+
+def _build_salute_token_cache_key(auth_token: str, scope: str) -> str:
+    payload = json.dumps(
+        {"auth_token": auth_token, "scope": scope},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
+    return f"salute:token:{digest}"
 
 
 async def _fetch_salute_token(auth_token: str, scope: str) -> str:
@@ -103,16 +117,77 @@ async def _fetch_salute_token(auth_token: str, scope: str) -> str:
         ) from exc
 
 
+async def _get_salute_token(auth_token: str, scope: str, *, force_refresh: bool = False) -> str:
+    cache_key = _build_salute_token_cache_key(auth_token=auth_token, scope=scope)
+    lock_key = f"{cache_key}:lock"
+
+    if not force_refresh:
+        cached = await cache.get(cache_key)
+        if isinstance(cached, str) and cached.strip():
+            return cached
+
+    async with cache.lock(lock_key, expire=30, wait=True):
+        if not force_refresh:
+            cached = await cache.get(cache_key)
+            if isinstance(cached, str) and cached.strip():
+                return cached
+
+        token = await _fetch_salute_token(auth_token=auth_token, scope=scope)
+        await cache.set(cache_key, token, expire=SALUTE_TOKEN_CACHE_TTL)
+        return token
+
+
+async def _recognize_with_salute(token: str, pcm: bytes) -> tuple[int, dict]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": f"audio/x-pcm;bit=16;rate={PCM_SAMPLE_RATE}",
+    }
+    params = {"language": "ru-RU"}
+
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(
+                SALUTE_SPEECH_RECOGNIZE_URL,
+                headers=headers,
+                params=params,
+                data=pcm,
+                ssl=False,
+                timeout=60,
+            ) as response,
+        ):
+            if response.status == 401:
+                return 401, {}
+            if response.status >= 400:
+                body = await response.text()
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"SaluteSpeech error {response.status}: {body}",
+                )
+            body = await response.json()
+            if not isinstance(body, dict):
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="Unexpected SaluteSpeech response shape",
+                )
+            return response.status, body
+    except aiohttp.ClientError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"SaluteSpeech transport error: {exc}",
+        ) from exc
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="SaluteSpeech request timed out",
+        ) from exc
+
+
 @router.post("/recognize", response_model=RecognizeResponse)
 async def recognize_speech(
     current_user: Annotated[User, Depends(get_current_active_user)],
     audio: UploadFile = File(...),
 ) -> RecognizeResponse:
-    if not GIGA_AGENT_STT_ENABLED:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="STT is disabled (set GIGA_AGENT_STT_ENABLED=1)",
-        )
     if (GIGA_AGENT_STT_RUNTIME or "").strip().lower() != "salute":
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -141,43 +216,11 @@ async def recognize_speech(
         ) from exc
 
     scope = os.environ.get("SALUTE_SCOPE", "SALUTE_SPEECH_PERS")
-    token = await _fetch_salute_token(auth_token=auth_token, scope=scope)
-
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": f"audio/x-pcm;bit=16;rate={PCM_SAMPLE_RATE}",
-    }
-    params = {"language": "ru-RU"}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.post(
-                SALUTE_SPEECH_RECOGNIZE_URL,
-                headers=headers,
-                params=params,
-                data=pcm,
-                ssl=False,
-                timeout=60,
-            ) as response,
-        ):
-            if response.status >= 400:
-                body = await response.text()
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=f"SaluteSpeech error {response.status}: {body}",
-                )
-            body = await response.json()
-    except aiohttp.ClientError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"SaluteSpeech transport error: {exc}",
-        ) from exc
-    except TimeoutError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-            detail="SaluteSpeech request timed out",
-        ) from exc
+    token = await _get_salute_token(auth_token=auth_token, scope=scope)
+    response_status, body = await _recognize_with_salute(token=token, pcm=pcm)
+    if response_status == 401:
+        token = await _get_salute_token(auth_token=auth_token, scope=scope, force_refresh=True)
+        _, body = await _recognize_with_salute(token=token, pcm=pcm)
 
     # SaluteSpeech returns {"status": 200, "result": ["transcribed text", ...]}
     parts = body.get("result") if isinstance(body, dict) else None

--- a/backend/giga_agent/runtime_config.py
+++ b/backend/giga_agent/runtime_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from urllib.parse import urlsplit
 
 from fastapi import FastAPI
@@ -11,8 +12,26 @@ from giga_agent.conf import (
     GIGA_AGENT_BASE_URL,
     GIGA_AGENT_PREFIX_API,
     GIGA_AGENT_SKIP_ONBOARDING,
+    GIGA_AGENT_STT_ENABLED,
+    GIGA_AGENT_STT_RUNTIME,
     GIGA_AGENT_UI_PREFIX,
 )
+
+
+def _stt_capability() -> dict[str, object]:
+    """Resolve which STT runtime, if any, the backend can serve right now.
+
+    The feature is only advertised as enabled if the flag is on AND the
+    credentials required by the chosen runtime are present — otherwise the
+    frontend would offer a button that always 503s.
+    """
+    if not GIGA_AGENT_STT_ENABLED:
+        return {"enabled": False, "runtime": None}
+    runtime = (GIGA_AGENT_STT_RUNTIME or "").strip().lower()
+    if runtime == "salute":
+        available = bool(os.environ.get("SALUTE_SPEECH"))
+        return {"enabled": available, "runtime": "salute" if available else None}
+    return {"enabled": False, "runtime": None}
 
 
 def normalize_base_path(value: str | None) -> str:
@@ -45,14 +64,15 @@ def resolve_ui_base_path(request: Request) -> str:
     return join_prefixed_path(root_path, ui_prefix)
 
 
-def build_runtime_config(request: Request) -> dict[str, str | bool]:
+def build_runtime_config(request: Request) -> dict[str, object]:
     base_path = resolve_ui_base_path(request)
     api_base_path = join_prefixed_path(base_path, "api")
-    config = {
+    config: dict[str, object] = {
         "basePath": base_path,
         "apiBasePath": api_base_path,
         "apiAgentBasePath": f"{api_base_path}{GIGA_AGENT_PREFIX_API}",
         "skipOnboarding": GIGA_AGENT_SKIP_ONBOARDING,
+        "stt": _stt_capability(),
     }
     if GIGA_AGENT_BASE_URL:
         config["baseUrl"] = GIGA_AGENT_BASE_URL

--- a/backend/giga_agent/runtime_config.py
+++ b/backend/giga_agent/runtime_config.py
@@ -12,7 +12,6 @@ from giga_agent.conf import (
     GIGA_AGENT_BASE_URL,
     GIGA_AGENT_PREFIX_API,
     GIGA_AGENT_SKIP_ONBOARDING,
-    GIGA_AGENT_STT_ENABLED,
     GIGA_AGENT_STT_RUNTIME,
     GIGA_AGENT_UI_PREFIX,
 )
@@ -21,12 +20,10 @@ from giga_agent.conf import (
 def _stt_capability() -> dict[str, object]:
     """Resolve which STT runtime, if any, the backend can serve right now.
 
-    The feature is only advertised as enabled if the flag is on AND the
-    credentials required by the chosen runtime are present — otherwise the
-    frontend would offer a button that always 503s.
+    The feature is advertised as enabled when a runtime is configured and the
+    credentials required by that runtime are present — otherwise the frontend
+    would offer a button that always 503s.
     """
-    if not GIGA_AGENT_STT_ENABLED:
-        return {"enabled": False, "runtime": None}
     runtime = (GIGA_AGENT_STT_RUNTIME or "").strip().lower()
     if runtime == "salute":
         available = bool(os.environ.get("SALUTE_SPEECH"))

--- a/front/src/components/Chat.tsx
+++ b/front/src/components/Chat.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
+import { ArrowDown } from "lucide-react";
 import MessageList from "./MessageList";
 import InputArea from "./InputArea";
 import { useStableMessages } from "../hooks/useStableMessages";
@@ -64,6 +65,7 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
       !/chrome|android/i.test(navigator.userAgent),
   );
   const firstSroll = useRef<boolean>(false);
+  const [showScrollBtn, setShowScrollBtn] = useState<boolean>(false);
   const stableMessages = useStableMessages(thread);
 
   const resolveScrollRoot = (): HTMLElement | null => {
@@ -243,12 +245,24 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
   const handleUserScroll = () => {
     const el = scrollRootRef.current;
     if (!el) return;
-    if (!userScrollIntentRef.current) return;
-    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 100;
-    if (!nearBottom) {
-      // Отключаем авто-скролл только если пользователь явно ушёл от низа
-      autoScrollEnabledRef.current = false;
+    const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight);
+    if (userScrollIntentRef.current) {
+      const nearBottom = distanceFromBottom <= 100;
+      if (!nearBottom) {
+        // Отключаем авто-скролл только если пользователь явно ушёл от низа
+        autoScrollEnabledRef.current = false;
+      }
     }
+    // Кнопка «вниз» появляется, когда пользователь проскроллил больше одного экрана от низа
+    setShowScrollBtn(distanceFromBottom > el.clientHeight);
+  };
+
+  const scrollToBottom = () => {
+    const el = scrollRootRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    autoScrollEnabledRef.current = true;
+    setShowScrollBtn(false);
   };
 
   useEffect(() => {
@@ -302,6 +316,17 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
           )}
         </div>
 
+        {showScrollBtn && stableMessages.length > 0 && (
+          <button
+            type="button"
+            onClick={scrollToBottom}
+            title="Прокрутить вниз"
+            aria-label="Прокрутить вниз"
+            className="sticky bottom-[118px] self-center z-20 w-9 h-9 flex items-center justify-center rounded-full bg-card dark:bg-input text-foreground/80 border border-border/60 shadow-[0_2px_10px_rgba(0,0,0,0.08)] hover:shadow-[0_4px_14px_rgba(0,0,0,0.12)] hover:text-foreground transition-all cursor-pointer print:hidden animate-in fade-in duration-150"
+          >
+            <ArrowDown className="size-4" strokeWidth={1.75} />
+          </button>
+        )}
         <InputArea
           // @ts-ignore
           thread={thread}

--- a/front/src/components/Chat.tsx
+++ b/front/src/components/Chat.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { ArrowDown } from "lucide-react";
 import MessageList from "./MessageList";
@@ -59,6 +59,8 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
   const userScrollIntentRef = useRef<boolean>(false);
   const resetIntentTimeoutRef = useRef<number | null>(null);
   const rafIdRef = useRef<number | null>(null);
+  const forceNextAutoScrollSmoothRef = useRef<boolean>(false);
+  const programmaticSmoothScrollRef = useRef<boolean>(false);
   const isSafariRef = useRef<boolean>(
     typeof navigator !== "undefined" &&
       /safari/i.test(navigator.userAgent) &&
@@ -213,7 +215,7 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
     };
   }, [stableMessages.length]);
 
-  const maybeAutoScroll = () => {
+  const maybeAutoScroll = useCallback(() => {
     const el = scrollRootRef.current;
     if (!el) return;
     if (!autoScrollEnabledRef.current) return;
@@ -222,7 +224,11 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
       rafIdRef.current = null;
       const current = scrollRootRef.current;
       if (!current) return;
-      if (isSafariRef.current || firstSroll.current) {
+      const shouldJump =
+        !forceNextAutoScrollSmoothRef.current &&
+        (isSafariRef.current || firstSroll.current);
+      forceNextAutoScrollSmoothRef.current = false;
+      if (shouldJump) {
         // Safari: избегаем smooth, чтобы не было скачков вверх
         current.scrollTop = current.scrollHeight;
       } else {
@@ -230,10 +236,11 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
       }
       firstSroll.current = true;
     });
-  };
+  }, [stableMessages.length]);
 
   const markUserScrollIntent = () => {
     userScrollIntentRef.current = true;
+    programmaticSmoothScrollRef.current = false;
     if (resetIntentTimeoutRef.current) {
       window.clearTimeout(resetIntentTimeoutRef.current);
     }
@@ -247,8 +254,15 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
     if (!el) return;
     const distanceFromBottom =
       el.scrollHeight - (el.scrollTop + el.clientHeight);
+    const nearBottom = distanceFromBottom <= 100;
+    if (programmaticSmoothScrollRef.current) {
+      if (nearBottom) {
+        programmaticSmoothScrollRef.current = false;
+      }
+      setShowScrollBtn(false);
+      return;
+    }
     if (userScrollIntentRef.current) {
-      const nearBottom = distanceFromBottom <= 100;
       if (!nearBottom) {
         // Отключаем авто-скролл только если пользователь явно ушёл от низа
         autoScrollEnabledRef.current = false;
@@ -261,6 +275,8 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
   const scrollToBottom = () => {
     const el = scrollRootRef.current;
     if (!el) return;
+    forceNextAutoScrollSmoothRef.current = true;
+    programmaticSmoothScrollRef.current = true;
     el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
     autoScrollEnabledRef.current = true;
     setShowScrollBtn(false);
@@ -323,7 +339,10 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
             onClick={scrollToBottom}
             title="Прокрутить вниз"
             aria-label="Прокрутить вниз"
-            className="sticky bottom-[118px] self-center z-20 w-9 h-9 flex items-center justify-center rounded-full bg-card dark:bg-input text-foreground/80 border border-border/60 shadow-[0_2px_10px_rgba(0,0,0,0.08)] hover:shadow-[0_4px_14px_rgba(0,0,0,0.12)] hover:text-foreground transition-all cursor-pointer print:hidden animate-in fade-in duration-150"
+            className="sticky bottom-[150px] self-center z-9 flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-card/80 py-[10px] text-foreground/80 shadow-[0_2px_10px_rgba(0,0,0,0.08)] transition-all hover:text-foreground hover:shadow-[0_4px_14px_rgba(0,0,0,0.12)] dark:bg-input/80 cursor-pointer print:hidden animate-in fade-in duration-150"
+            style={{
+              backdropFilter: "blur(2px)"
+            }}
           >
             <ArrowDown className="size-4" strokeWidth={1.75} />
           </button>

--- a/front/src/components/Chat.tsx
+++ b/front/src/components/Chat.tsx
@@ -245,7 +245,8 @@ const Chat: React.FC<ChatProps> = ({ onThreadIdChange, onThreadReady }) => {
   const handleUserScroll = () => {
     const el = scrollRootRef.current;
     if (!el) return;
-    const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight);
+    const distanceFromBottom =
+      el.scrollHeight - (el.scrollTop + el.clientHeight);
     if (userScrollIntentRef.current) {
       const nearBottom = distanceFromBottom <= 100;
       if (!nearBottom) {

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -609,48 +609,46 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
     [uploadFiles, isBusy],
   );
 
-  const handleDragEnter = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      if (isBusy) return;
-      if (!Array.from(e.dataTransfer?.types ?? []).includes("Files")) return;
+  useEffect(() => {
+    const hasFiles = (e: DragEvent) =>
+      Array.from(e.dataTransfer?.types ?? []).includes("Files");
+
+    const onDragEnter = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
       e.preventDefault();
       dragCounterRef.current += 1;
-      setIsDragging(true);
-    },
-    [isBusy],
-  );
-
-  const handleDragOver = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      if (isBusy) return;
-      if (!Array.from(e.dataTransfer?.types ?? []).includes("Files")) return;
+      if (!isBusy) setIsDragging(true);
+    };
+    const onDragOver = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
       e.preventDefault();
-      e.dataTransfer.dropEffect = "copy";
-    },
-    [isBusy],
-  );
-
-  const handleDragLeave = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      if (isBusy) return;
-      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = isBusy ? "none" : "copy";
+    };
+    const onDragLeave = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
       dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
       if (dragCounterRef.current === 0) setIsDragging(false);
-    },
-    [isBusy],
-  );
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      if (isBusy) return;
+    };
+    const onDrop = (e: DragEvent) => {
       e.preventDefault();
       dragCounterRef.current = 0;
       setIsDragging(false);
+      if (isBusy) return;
       const files = Array.from(e.dataTransfer?.files ?? []);
       if (files.length > 0) uploadFiles(files);
-    },
-    [uploadFiles, isBusy],
-  );
+    };
+
+    window.addEventListener("dragenter", onDragEnter);
+    window.addEventListener("dragover", onDragOver);
+    window.addEventListener("dragleave", onDragLeave);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragenter", onDragEnter);
+      window.removeEventListener("dragover", onDragOver);
+      window.removeEventListener("dragleave", onDragLeave);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [uploadFiles, isBusy]);
 
   const handleOpenDocuments = useCallback(async () => {
     if (collections.length > 0) {
@@ -689,18 +687,14 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
 
   return (
     <div className="bg-card w-full sticky bottom-0 p-5 pt-0 max-[900px]:p-0 z-9">
-      <div
-        className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight max-w-[900px] mx-auto overflow-hidden"
-        onDragEnter={handleDragEnter}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        {isDragging && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-card/90 dark:bg-input/90 pointer-events-none text-sm text-foreground">
+      {isDragging && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/70 backdrop-blur-sm pointer-events-none print:hidden animate-in fade-in duration-150">
+          <div className="m-6 px-8 py-10 rounded-2xl border-2 border-dashed border-primary bg-card/95 dark:bg-input/95 shadow-xl text-foreground text-base font-medium">
             Отпустите, чтобы прикрепить файлы
           </div>
-        )}
+        </div>
+      )}
+      <div className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight max-w-[900px] mx-auto overflow-hidden">
         <div className="flex items-end gap-2 relative">
           <input
             className="hidden"

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -16,11 +16,13 @@ import {
   Printer,
   Mic,
   Loader2,
+  Check,
+  X,
 } from "lucide-react";
 import { useSettings } from "./Settings.tsx";
 import { useFileUpload, UploadedFile } from "../hooks/useFileUploads";
 import { apiClient, ApiError } from "../lib/api-client.ts";
-import { API_AGENT_PREFIX } from "../config.ts";
+import { API_AGENT_PREFIX, BACKEND_STT_ENABLED } from "../config.ts";
 import { toast } from "sonner";
 import { useSelectedAttachments } from "../hooks/SelectedAttachmentsContext.tsx";
 import {
@@ -51,6 +53,43 @@ import {
 
 const MAX_TEXTAREA_HEIGHT = 200; // макс высота в px
 
+type BrowserSpeechRecognitionInstance = {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((event: Event) => void) | null;
+  onerror: ((event: Event) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+};
+type BrowserSpeechRecognitionCtor = new () => BrowserSpeechRecognitionInstance;
+
+const BrowserSpeechRecognitionClass: BrowserSpeechRecognitionCtor | undefined =
+  typeof window !== "undefined"
+    ? (((window as unknown as Record<string, unknown>).SpeechRecognition as
+        | BrowserSpeechRecognitionCtor
+        | undefined) ??
+      ((window as unknown as Record<string, unknown>)
+        .webkitSpeechRecognition as BrowserSpeechRecognitionCtor | undefined))
+    : undefined;
+
+type SttSource = "backend" | "browser" | null;
+
+const resolveSttSource = (): SttSource => {
+  if (typeof window === "undefined") return null;
+  if (
+    BACKEND_STT_ENABLED &&
+    typeof window.MediaRecorder !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia
+  ) {
+    return "backend";
+  }
+  if (BrowserSpeechRecognitionClass) return "browser";
+  return null;
+};
+
 // Прочие стили для превью и оверлея оставляем без изменений...
 
 interface InputAreaProps {
@@ -72,10 +111,14 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
   const [isMCPLoading, setIsMCPLoading] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
-  const [micSupported, setMicSupported] = useState(false);
+  const sttSource = useMemo<SttSource>(() => resolveSttSource(), []);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
   const recordedChunksRef = useRef<Blob[]>([]);
+  const browserRecognitionRef = useRef<BrowserSpeechRecognitionInstance | null>(
+    null,
+  );
+  const browserTranscriptRef = useRef("");
   const cancelRecordingRef = useRef(false);
 
   const {
@@ -204,18 +247,16 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
   }, []);
 
   useEffect(() => {
-    const supported =
-      typeof navigator !== "undefined" &&
-      !!navigator.mediaDevices?.getUserMedia &&
-      typeof window.MediaRecorder !== "undefined";
-    setMicSupported(supported);
-  }, []);
-
-  useEffect(() => {
     return () => {
       mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
       mediaStreamRef.current = null;
       mediaRecorderRef.current = null;
+      try {
+        browserRecognitionRef.current?.abort();
+      } catch {
+        /* instance may be already stopped */
+      }
+      browserRecognitionRef.current = null;
     };
   }, []);
 
@@ -250,55 +291,14 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
     });
   }, []);
 
-  const teardownRecording = useCallback(() => {
+  const teardownBackendRecording = useCallback(() => {
     mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
     mediaStreamRef.current = null;
     mediaRecorderRef.current = null;
     recordedChunksRef.current = [];
   }, []);
 
-  const startRecording = useCallback(async () => {
-    if (isRecording || isTranscribing || !micSupported) return;
-    if (thread?.isLoading || isMCPLoading) return;
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      mediaStreamRef.current = stream;
-      const candidates = [
-        "audio/webm;codecs=opus",
-        "audio/ogg;codecs=opus",
-        "audio/webm",
-        "audio/mp4",
-      ];
-      const mimeType = candidates.find((c) =>
-        typeof MediaRecorder.isTypeSupported === "function"
-          ? MediaRecorder.isTypeSupported(c)
-          : false,
-      );
-      const rec = mimeType
-        ? new MediaRecorder(stream, { mimeType })
-        : new MediaRecorder(stream);
-      recordedChunksRef.current = [];
-      rec.addEventListener("dataavailable", (e) => {
-        if (e.data && e.data.size > 0) recordedChunksRef.current.push(e.data);
-      });
-      mediaRecorderRef.current = rec;
-      cancelRecordingRef.current = false;
-      rec.start();
-      setIsRecording(true);
-    } catch {
-      teardownRecording();
-      setIsRecording(false);
-    }
-  }, [
-    isRecording,
-    isTranscribing,
-    micSupported,
-    thread?.isLoading,
-    isMCPLoading,
-    teardownRecording,
-  ]);
-
-  const finishRecording = useCallback(
+  const finishBackendRecording = useCallback(
     async (cancelled: boolean) => {
       const rec = mediaRecorderRef.current;
       if (!rec) {
@@ -324,7 +324,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
         }
       });
       const mime = rec.mimeType || "audio/webm";
-      teardownRecording();
+      teardownBackendRecording();
       setIsRecording(false);
 
       if (cancelled || blob.size === 0) return;
@@ -361,21 +361,130 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
         setIsTranscribing(false);
       }
     },
-    [teardownRecording, insertAtCursor],
+    [teardownBackendRecording, insertAtCursor],
   );
 
-  const stopRecording = useCallback(() => {
-    if (!isRecording) return;
-    const cancelled = cancelRecordingRef.current;
+  const startRecording = useCallback(async () => {
+    if (isRecording || isTranscribing) return;
+    if (thread?.isLoading || isMCPLoading) return;
+    if (!sttSource) return;
     cancelRecordingRef.current = false;
-    void finishRecording(cancelled);
-  }, [isRecording, finishRecording]);
+
+    if (sttSource === "backend") {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: true,
+        });
+        mediaStreamRef.current = stream;
+        const candidates = [
+          "audio/webm;codecs=opus",
+          "audio/ogg;codecs=opus",
+          "audio/webm",
+          "audio/mp4",
+        ];
+        const mimeType = candidates.find((c) =>
+          typeof MediaRecorder.isTypeSupported === "function"
+            ? MediaRecorder.isTypeSupported(c)
+            : false,
+        );
+        const rec = mimeType
+          ? new MediaRecorder(stream, { mimeType })
+          : new MediaRecorder(stream);
+        recordedChunksRef.current = [];
+        rec.addEventListener("dataavailable", (e) => {
+          if (e.data && e.data.size > 0) recordedChunksRef.current.push(e.data);
+        });
+        mediaRecorderRef.current = rec;
+        rec.start();
+        setIsRecording(true);
+      } catch {
+        teardownBackendRecording();
+        setIsRecording(false);
+      }
+      return;
+    }
+
+    // Browser Web Speech API path
+    const Ctor = BrowserSpeechRecognitionClass;
+    if (!Ctor) return;
+    try {
+      const rec = new Ctor();
+      rec.lang = navigator.language || "ru-RU";
+      rec.continuous = true;
+      rec.interimResults = false;
+      browserTranscriptRef.current = "";
+      rec.onresult = (event: Event) => {
+        const anyEvent = event as unknown as {
+          resultIndex: number;
+          results: ArrayLike<
+            ArrayLike<{ transcript: string }> & { isFinal: boolean }
+          >;
+        };
+        for (let i = anyEvent.resultIndex; i < anyEvent.results.length; i++) {
+          const result = anyEvent.results[i];
+          if (result.isFinal) {
+            browserTranscriptRef.current += result[0].transcript;
+          }
+        }
+      };
+      rec.onerror = () => {
+        cancelRecordingRef.current = true;
+      };
+      rec.onend = () => {
+        const wasCancelled = cancelRecordingRef.current;
+        const transcript = browserTranscriptRef.current.trim();
+        browserRecognitionRef.current = null;
+        cancelRecordingRef.current = false;
+        browserTranscriptRef.current = "";
+        setIsRecording(false);
+        if (!wasCancelled && transcript) insertAtCursor(transcript);
+      };
+      browserRecognitionRef.current = rec;
+      rec.start();
+      setIsRecording(true);
+    } catch {
+      browserRecognitionRef.current = null;
+      setIsRecording(false);
+    }
+  }, [
+    isRecording,
+    isTranscribing,
+    sttSource,
+    thread?.isLoading,
+    isMCPLoading,
+    teardownBackendRecording,
+    insertAtCursor,
+  ]);
+
+  const acceptRecording = useCallback(() => {
+    if (!isRecording) return;
+    if (sttSource === "backend") {
+      cancelRecordingRef.current = false;
+      void finishBackendRecording(false);
+      return;
+    }
+    cancelRecordingRef.current = false;
+    try {
+      browserRecognitionRef.current?.stop();
+    } catch {
+      /* stop may throw if already ended */
+    }
+  }, [isRecording, sttSource, finishBackendRecording]);
 
   const cancelRecording = useCallback(() => {
     if (!isRecording) return;
+    if (sttSource === "backend") {
+      cancelRecordingRef.current = true;
+      void finishBackendRecording(true);
+      return;
+    }
     cancelRecordingRef.current = true;
-    void finishRecording(true);
-  }, [isRecording, finishRecording]);
+    try {
+      browserRecognitionRef.current?.abort();
+    } catch {
+      /* abort may throw if already ended */
+    }
+  }, [isRecording, sttSource, finishBackendRecording]);
 
   const handleContinue = useCallback(
     async (type: "comment" | "approve") => {
@@ -569,152 +678,144 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
     openCollectionsModal,
   ]);
 
+  const showMicButton =
+    sttSource !== null &&
+    !isRecording &&
+    !isTranscribing &&
+    !isBusy &&
+    !message.trim() &&
+    uploads.length === 0 &&
+    !thread?.interrupt;
+
   return (
     <div className="bg-card w-full sticky bottom-0 p-5 pt-0 max-[900px]:p-0 z-9">
-      <div className="relative max-w-[900px] mx-auto">
-        <label
-          data-onboarding="autonomy-switch"
-          className="absolute -top-5 right-2 flex items-center gap-2 select-none text-[11px] text-muted-foreground leading-none z-20 bg-card/80 rounded px-1"
-        >
-          <span>Автономность</span>
-          <Switch
-            checked={settings.autoApprove ?? false}
-            onCheckedChange={(checked) =>
-              setSettings((prev) => ({ ...prev, autoApprove: checked }))
-            }
+      <div
+        className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight max-w-[900px] mx-auto overflow-hidden"
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {isDragging && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-card/90 dark:bg-input/90 pointer-events-none text-sm text-foreground">
+            Отпустите, чтобы прикрепить файлы
+          </div>
+        )}
+        <div className="flex items-end gap-2 relative">
+          <input
+            className="hidden"
+            type="file"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            multiple
+            disabled={thread?.isLoading || isMCPLoading}
           />
-        </label>
-        <div
-          className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight overflow-hidden"
-          onDragEnter={handleDragEnter}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-        >
-          {isDragging && (
-            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-card/90 dark:bg-input/90 pointer-events-none text-sm text-foreground">
-              Отпустите, чтобы прикрепить файлы
-            </div>
-          )}
-          <div className="flex items-end gap-2 relative">
-            <input
-              className="hidden"
-              type="file"
-              ref={fileInputRef}
-              onChange={handleFileChange}
-              multiple
-              disabled={thread?.isLoading || isMCPLoading}
-            />
-            <div className="flex flex-col items-center gap-1">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    data-onboarding="gear-menu-btn"
-                    type="button"
-                    disabled={thread?.isLoading || isMCPLoading}
-                    title="Открыть настройки"
-                    className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
-                  >
-                    <Settings2 />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  className="input-dropdown"
-                  align="start"
-                  sideOffset={3}
+          <div className="flex flex-col items-center gap-1">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  data-onboarding="gear-menu-btn"
+                  type="button"
+                  disabled={thread?.isLoading || isMCPLoading}
+                  title="Открыть настройки"
+                  className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
                 >
-                  <DropdownMenuItem onSelect={openContextModal}>
-                    <Brain className={"size-5"} />
-                    <span>Персонализация</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={openMcpModal}>
-                    <Cog className={"size-5"} />
-                    <span>Инструменты</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => void handleOpenDocuments()}>
-                    <Files className={"size-5"} />
-                    <span>Документы</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => window.print()}>
-                    <Printer className={"size-5"} />
-                    <span>Печать</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <button
-                data-onboarding="attachments-btn"
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={thread?.isLoading || isMCPLoading}
-                title="Добавить вложения"
-                className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
+                  <Settings2 />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="input-dropdown"
+                align="start"
+                sideOffset={3}
               >
-                <Paperclip />
-              </button>
-            </div>
-
-            <textarea
-              data-onboarding="chat-input"
-              placeholder={
-                thread?.interrupt
-                  ? "Принять / Отменить с комментарием…"
-                  : "Введите вашу задачу…"
-              }
-              ref={textRef}
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onPaste={handlePaste}
+                <DropdownMenuItem onSelect={openContextModal}>
+                  <Brain className={"size-5"} />
+                  <span>Персонализация</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={openMcpModal}>
+                  <Cog className={"size-5"} />
+                  <span>Инструменты</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => void handleOpenDocuments()}>
+                  <Files className={"size-5"} />
+                  <span>Документы</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => window.print()}>
+                  <Printer className={"size-5"} />
+                  <span>Печать</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <button
+              data-onboarding="attachments-btn"
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
               disabled={thread?.isLoading || isMCPLoading}
-              className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60"
-            />
-            <div className="flex flex-col items-end gap-1">
-              {micSupported && (
+              title="Добавить вложения"
+              className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
+            >
+              <Paperclip />
+            </button>
+          </div>
+
+          <textarea
+            data-onboarding="chat-input"
+            placeholder={
+              thread?.interrupt
+                ? "Принять / Отменить с комментарием…"
+                : "Введите вашу задачу…"
+            }
+            ref={textRef}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            disabled={thread?.isLoading || isMCPLoading}
+            className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60"
+          />
+          <div className="flex flex-col items-end gap-1">
+            {isRecording ? (
+              <>
                 <button
                   type="button"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    void startRecording();
-                  }}
-                  onMouseUp={(e) => {
-                    e.preventDefault();
-                    stopRecording();
-                  }}
-                  onMouseLeave={() => {
-                    if (isRecording) cancelRecording();
-                  }}
-                  onTouchStart={(e) => {
-                    e.preventDefault();
-                    void startRecording();
-                  }}
-                  onTouchEnd={(e) => {
-                    e.preventDefault();
-                    stopRecording();
-                  }}
-                  onTouchCancel={cancelRecording}
-                  onContextMenu={(e) => e.preventDefault()}
-                  disabled={thread?.isLoading || isMCPLoading || isTranscribing}
-                  title={
-                    isRecording
-                      ? "Отпустите, чтобы распознать"
-                      : "Зажмите и диктуйте"
-                  }
-                  aria-label="Голосовой ввод"
-                  aria-pressed={isRecording}
-                  className={[
-                    "w-9 h-9 p-0 rounded-full flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67 select-none",
-                    isRecording
-                      ? "bg-red-500/15 text-red-500 animate-pulse"
-                      : "text-foreground",
-                  ].join(" ")}
+                  onClick={cancelRecording}
+                  title="Отменить запись"
+                  aria-label="Отменить запись"
+                  className="w-9 h-9 p-0 rounded-full text-destructive hover:bg-destructive/10 flex items-center justify-center transition-colors cursor-pointer outline-hidden"
                 >
-                  {isTranscribing ? (
-                    <Loader2 className="animate-spin" />
-                  ) : (
-                    <Mic />
-                  )}
+                  <X />
                 </button>
-              )}
+                <button
+                  type="button"
+                  onClick={acceptRecording}
+                  title="Готово"
+                  aria-label="Готово"
+                  className="w-9 h-9 p-0 rounded-full bg-red-500/15 text-red-500 animate-pulse flex items-center justify-center transition-colors cursor-pointer outline-hidden"
+                >
+                  <Check />
+                </button>
+              </>
+            ) : isTranscribing ? (
+              <button
+                type="button"
+                disabled
+                title="Распознавание…"
+                aria-label="Распознавание"
+                className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center outline-hidden"
+              >
+                <Loader2 className="animate-spin" />
+              </button>
+            ) : showMicButton ? (
+              <button
+                type="button"
+                onClick={() => void startRecording()}
+                title="Голосовой ввод"
+                aria-label="Голосовой ввод"
+                className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden"
+              >
+                <Mic />
+              </button>
+            ) : (
               <button
                 type="button"
                 onClick={handleSend}
@@ -729,65 +830,73 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
               >
                 <Send />
               </button>
-            </div>
+            )}
           </div>
-
-          {uploads.length > 0 && (
-            <AttachmentsContainer>
-              {uploads.map((u: UploadedFile, idx) => (
-                <AttachmentBubble
-                  key={idx}
-                  onClick={() =>
-                    u.previewUrl && setEnlargedImage(u.previewUrl!)
-                  }
-                >
-                  {u.previewUrl ? (
-                    <ImagePreview src={u.previewUrl} />
-                  ) : (
-                    <span>{u.file.name}</span>
-                  )}
-
-                  {u.progress < 100 && (
-                    <ProgressOverlay>
-                      <CircularProgress progress={u.progress}>
-                        {u.progress}%
-                      </CircularProgress>
-                    </ProgressOverlay>
-                  )}
-
-                  <RemoveButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      removeUpload(idx);
-                    }}
-                  >
-                    ×
-                  </RemoveButton>
-                </AttachmentBubble>
-              ))}
-            </AttachmentsContainer>
-          )}
-
-          <div
-            className={[
-              "absolute bottom-2 left-[75px] text-muted-foreground text-xs pointer-events-none transition-opacity duration-100",
-              selectedCount > 0
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-1",
-            ].join(" ")}
+          <label
+            data-onboarding="autonomy-switch"
+            className="absolute top-0 right-0 flex items-center gap-2 select-none text-[11px] text-muted-foreground leading-none"
           >
-            Выбрано вложений: {selectedCount}
-          </div>
-
-          {enlargedImage && (
-            <Overlay onClick={() => setEnlargedImage(null)}>
-              <EnlargedImage src={enlargedImage} />
-              <CloseButton onClick={() => setEnlargedImage(null)}>
-                ×
-              </CloseButton>
-            </Overlay>
-          )}
+            <span>Автономность</span>
+            <Switch
+              checked={settings.autoApprove ?? false}
+              onCheckedChange={(checked) =>
+                setSettings((prev) => ({ ...prev, autoApprove: checked }))
+              }
+            />
+          </label>
         </div>
+
+        {uploads.length > 0 && (
+          <AttachmentsContainer>
+            {uploads.map((u: UploadedFile, idx) => (
+              <AttachmentBubble
+                key={idx}
+                onClick={() => u.previewUrl && setEnlargedImage(u.previewUrl!)}
+              >
+                {u.previewUrl ? (
+                  <ImagePreview src={u.previewUrl} />
+                ) : (
+                  <span>{u.file.name}</span>
+                )}
+
+                {u.progress < 100 && (
+                  <ProgressOverlay>
+                    <CircularProgress progress={u.progress}>
+                      {u.progress}%
+                    </CircularProgress>
+                  </ProgressOverlay>
+                )}
+
+                <RemoveButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeUpload(idx);
+                  }}
+                >
+                  ×
+                </RemoveButton>
+              </AttachmentBubble>
+            ))}
+          </AttachmentsContainer>
+        )}
+
+        <div
+          className={[
+            "absolute bottom-2 left-[75px] text-muted-foreground text-xs pointer-events-none transition-opacity duration-100",
+            selectedCount > 0
+              ? "opacity-100 translate-y-0"
+              : "opacity-0 translate-y-1",
+          ].join(" ")}
+        >
+          Выбрано вложений: {selectedCount}
+        </div>
+
+        {enlargedImage && (
+          <Overlay onClick={() => setEnlargedImage(null)}>
+            <EnlargedImage src={enlargedImage} />
+            <CloseButton onClick={() => setEnlargedImage(null)}>×</CloseButton>
+          </Overlay>
+        )}
       </div>
     </div>
   );

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -50,6 +50,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import ModelPicker from "./ModelPicker";
 
 const MAX_TEXTAREA_HEIGHT = 200; // макс высота в px
 
@@ -767,6 +768,9 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
             disabled={thread?.isLoading || isMCPLoading}
             className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60"
           />
+          <div className="self-end mb-1 shrink-0">
+            <ModelPicker disabled={thread?.isLoading || isMCPLoading} />
+          </div>
           <div className="flex flex-col items-end gap-1">
             {isRecording ? (
               <>

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -584,208 +584,210 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
             }
           />
         </label>
-      <div
-        className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight overflow-hidden"
-        onDragEnter={handleDragEnter}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        {isDragging && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-card/90 dark:bg-input/90 pointer-events-none text-sm text-foreground">
-            Отпустите, чтобы прикрепить файлы
-          </div>
-        )}
-        <div className="flex items-end gap-2 relative">
-          <input
-            className="hidden"
-            type="file"
-            ref={fileInputRef}
-            onChange={handleFileChange}
-            multiple
-            disabled={thread?.isLoading || isMCPLoading}
-          />
-          <div className="flex flex-col items-center gap-1">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  data-onboarding="gear-menu-btn"
-                  type="button"
-                  disabled={thread?.isLoading || isMCPLoading}
-                  title="Открыть настройки"
-                  className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
-                >
-                  <Settings2 />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                className="input-dropdown"
-                align="start"
-                sideOffset={3}
-              >
-                <DropdownMenuItem onSelect={openContextModal}>
-                  <Brain className={"size-5"} />
-                  <span>Персонализация</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={openMcpModal}>
-                  <Cog className={"size-5"} />
-                  <span>Инструменты</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => void handleOpenDocuments()}>
-                  <Files className={"size-5"} />
-                  <span>Документы</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => window.print()}>
-                  <Printer className={"size-5"} />
-                  <span>Печать</span>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <button
-              data-onboarding="attachments-btn"
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
+        <div
+          className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight overflow-hidden"
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {isDragging && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-card/90 dark:bg-input/90 pointer-events-none text-sm text-foreground">
+              Отпустите, чтобы прикрепить файлы
+            </div>
+          )}
+          <div className="flex items-end gap-2 relative">
+            <input
+              className="hidden"
+              type="file"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+              multiple
               disabled={thread?.isLoading || isMCPLoading}
-              title="Добавить вложения"
-              className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
-            >
-              <Paperclip />
-            </button>
-          </div>
+            />
+            <div className="flex flex-col items-center gap-1">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    data-onboarding="gear-menu-btn"
+                    type="button"
+                    disabled={thread?.isLoading || isMCPLoading}
+                    title="Открыть настройки"
+                    className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
+                  >
+                    <Settings2 />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  className="input-dropdown"
+                  align="start"
+                  sideOffset={3}
+                >
+                  <DropdownMenuItem onSelect={openContextModal}>
+                    <Brain className={"size-5"} />
+                    <span>Персонализация</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={openMcpModal}>
+                    <Cog className={"size-5"} />
+                    <span>Инструменты</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void handleOpenDocuments()}>
+                    <Files className={"size-5"} />
+                    <span>Документы</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => window.print()}>
+                    <Printer className={"size-5"} />
+                    <span>Печать</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <button
+                data-onboarding="attachments-btn"
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={thread?.isLoading || isMCPLoading}
+                title="Добавить вложения"
+                className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
+              >
+                <Paperclip />
+              </button>
+            </div>
 
-          <textarea
-            data-onboarding="chat-input"
-            placeholder={
-              thread?.interrupt
-                ? "Принять / Отменить с комментарием…"
-                : "Введите вашу задачу…"
-            }
-            ref={textRef}
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            disabled={thread?.isLoading || isMCPLoading}
-            className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60"
-          />
-          <div className="flex flex-col items-end gap-1">
-            {micSupported && (
+            <textarea
+              data-onboarding="chat-input"
+              placeholder={
+                thread?.interrupt
+                  ? "Принять / Отменить с комментарием…"
+                  : "Введите вашу задачу…"
+              }
+              ref={textRef}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
+              disabled={thread?.isLoading || isMCPLoading}
+              className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60"
+            />
+            <div className="flex flex-col items-end gap-1">
+              {micSupported && (
+                <button
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    void startRecording();
+                  }}
+                  onMouseUp={(e) => {
+                    e.preventDefault();
+                    stopRecording();
+                  }}
+                  onMouseLeave={() => {
+                    if (isRecording) cancelRecording();
+                  }}
+                  onTouchStart={(e) => {
+                    e.preventDefault();
+                    void startRecording();
+                  }}
+                  onTouchEnd={(e) => {
+                    e.preventDefault();
+                    stopRecording();
+                  }}
+                  onTouchCancel={cancelRecording}
+                  onContextMenu={(e) => e.preventDefault()}
+                  disabled={thread?.isLoading || isMCPLoading || isTranscribing}
+                  title={
+                    isRecording
+                      ? "Отпустите, чтобы распознать"
+                      : "Зажмите и диктуйте"
+                  }
+                  aria-label="Голосовой ввод"
+                  aria-pressed={isRecording}
+                  className={[
+                    "w-9 h-9 p-0 rounded-full flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67 select-none",
+                    isRecording
+                      ? "bg-red-500/15 text-red-500 animate-pulse"
+                      : "text-foreground",
+                  ].join(" ")}
+                >
+                  {isTranscribing ? (
+                    <Loader2 className="animate-spin" />
+                  ) : (
+                    <Mic />
+                  )}
+                </button>
+              )}
               <button
                 type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  void startRecording();
-                }}
-                onMouseUp={(e) => {
-                  e.preventDefault();
-                  stopRecording();
-                }}
-                onMouseLeave={() => {
-                  if (isRecording) cancelRecording();
-                }}
-                onTouchStart={(e) => {
-                  e.preventDefault();
-                  void startRecording();
-                }}
-                onTouchEnd={(e) => {
-                  e.preventDefault();
-                  stopRecording();
-                }}
-                onTouchCancel={cancelRecording}
-                onContextMenu={(e) => e.preventDefault()}
+                onClick={handleSend}
                 disabled={
-                  thread?.isLoading || isMCPLoading || isTranscribing
+                  thread?.isLoading ||
+                  isMCPLoading ||
+                  !message.trim() ||
+                  isUploading
                 }
-                title={
-                  isRecording
-                    ? "Отпустите, чтобы распознать"
-                    : "Зажмите и диктуйте"
-                }
-                aria-label="Голосовой ввод"
-                aria-pressed={isRecording}
-                className={[
-                  "w-9 h-9 p-0 rounded-full flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67 select-none",
-                  isRecording
-                    ? "bg-red-500/15 text-red-500 animate-pulse"
-                    : "text-foreground",
-                ].join(" ")}
+                title="Отправить"
+                className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
               >
-                {isTranscribing ? (
-                  <Loader2 className="animate-spin" />
-                ) : (
-                  <Mic />
-                )}
+                <Send />
               </button>
-            )}
-            <button
-              type="button"
-              onClick={handleSend}
-              disabled={
-                thread?.isLoading ||
-                isMCPLoading ||
-                !message.trim() ||
-                isUploading
-              }
-              title="Отправить"
-              className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
-            >
-              <Send />
-            </button>
+            </div>
           </div>
-        </div>
 
-        {uploads.length > 0 && (
-          <AttachmentsContainer>
-            {uploads.map((u: UploadedFile, idx) => (
-              <AttachmentBubble
-                key={idx}
-                onClick={() => u.previewUrl && setEnlargedImage(u.previewUrl!)}
-              >
-                {u.previewUrl ? (
-                  <ImagePreview src={u.previewUrl} />
-                ) : (
-                  <span>{u.file.name}</span>
-                )}
-
-                {u.progress < 100 && (
-                  <ProgressOverlay>
-                    <CircularProgress progress={u.progress}>
-                      {u.progress}%
-                    </CircularProgress>
-                  </ProgressOverlay>
-                )}
-
-                <RemoveButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    removeUpload(idx);
-                  }}
+          {uploads.length > 0 && (
+            <AttachmentsContainer>
+              {uploads.map((u: UploadedFile, idx) => (
+                <AttachmentBubble
+                  key={idx}
+                  onClick={() =>
+                    u.previewUrl && setEnlargedImage(u.previewUrl!)
+                  }
                 >
-                  ×
-                </RemoveButton>
-              </AttachmentBubble>
-            ))}
-          </AttachmentsContainer>
-        )}
+                  {u.previewUrl ? (
+                    <ImagePreview src={u.previewUrl} />
+                  ) : (
+                    <span>{u.file.name}</span>
+                  )}
 
-        <div
-          className={[
-            "absolute bottom-2 left-[75px] text-muted-foreground text-xs pointer-events-none transition-opacity duration-100",
-            selectedCount > 0
-              ? "opacity-100 translate-y-0"
-              : "opacity-0 translate-y-1",
-          ].join(" ")}
-        >
-          Выбрано вложений: {selectedCount}
+                  {u.progress < 100 && (
+                    <ProgressOverlay>
+                      <CircularProgress progress={u.progress}>
+                        {u.progress}%
+                      </CircularProgress>
+                    </ProgressOverlay>
+                  )}
+
+                  <RemoveButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeUpload(idx);
+                    }}
+                  >
+                    ×
+                  </RemoveButton>
+                </AttachmentBubble>
+              ))}
+            </AttachmentsContainer>
+          )}
+
+          <div
+            className={[
+              "absolute bottom-2 left-[75px] text-muted-foreground text-xs pointer-events-none transition-opacity duration-100",
+              selectedCount > 0
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-1",
+            ].join(" ")}
+          >
+            Выбрано вложений: {selectedCount}
+          </div>
+
+          {enlargedImage && (
+            <Overlay onClick={() => setEnlargedImage(null)}>
+              <EnlargedImage src={enlargedImage} />
+              <CloseButton onClick={() => setEnlargedImage(null)}>
+                ×
+              </CloseButton>
+            </Overlay>
+          )}
         </div>
-
-        {enlargedImage && (
-          <Overlay onClick={() => setEnlargedImage(null)}>
-            <EnlargedImage src={enlargedImage} />
-            <CloseButton onClick={() => setEnlargedImage(null)}>×</CloseButton>
-          </Overlay>
-        )}
-      </div>
       </div>
     </div>
   );

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -57,6 +57,8 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
   const [message, setMessage] = useState("");
   const [isMobileDevice, setIsMobileDevice] = useState(false);
   const [enlargedImage, setEnlargedImage] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounterRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textRef = useRef<HTMLTextAreaElement>(null);
   const { uploads, uploadFiles, removeUpload, resetUploads } = useFileUpload();
@@ -289,6 +291,72 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
     }
   };
 
+  const isBusy = thread?.isLoading || isMCPLoading;
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      if (isBusy) return;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      const files: File[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.kind === "file") {
+          const file = item.getAsFile();
+          if (file) files.push(file);
+        }
+      }
+      if (files.length > 0) {
+        e.preventDefault();
+        uploadFiles(files);
+      }
+    },
+    [uploadFiles, isBusy],
+  );
+
+  const handleDragEnter = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (isBusy) return;
+      if (!Array.from(e.dataTransfer?.types ?? []).includes("Files")) return;
+      e.preventDefault();
+      dragCounterRef.current += 1;
+      setIsDragging(true);
+    },
+    [isBusy],
+  );
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (isBusy) return;
+      if (!Array.from(e.dataTransfer?.types ?? []).includes("Files")) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "copy";
+    },
+    [isBusy],
+  );
+
+  const handleDragLeave = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (isBusy) return;
+      e.preventDefault();
+      dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+      if (dragCounterRef.current === 0) setIsDragging(false);
+    },
+    [isBusy],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (isBusy) return;
+      e.preventDefault();
+      dragCounterRef.current = 0;
+      setIsDragging(false);
+      const files = Array.from(e.dataTransfer?.files ?? []);
+      if (files.length > 0) uploadFiles(files);
+    },
+    [uploadFiles, isBusy],
+  );
+
   const handleOpenDocuments = useCallback(async () => {
     if (collections.length > 0) {
       openCollectionsModal();
@@ -317,7 +385,18 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
 
   return (
     <div className="bg-card w-full sticky bottom-0 p-5 pt-0 max-[900px]:p-0 z-9">
-      <div className="p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight max-w-[900px] mx-auto overflow-hidden">
+      <div
+        className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight max-w-[900px] mx-auto overflow-hidden"
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {isDragging && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-card/90 dark:bg-input/90 pointer-events-none text-sm text-foreground">
+            Отпустите, чтобы прикрепить файлы
+          </div>
+        )}
         <div className="flex items-end gap-2 relative">
           <input
             className="hidden"
@@ -386,6 +465,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             disabled={thread?.isLoading || isMCPLoading}
             className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60"
           />

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -14,9 +14,14 @@ import {
   Files,
   Cog,
   Printer,
+  Mic,
+  Loader2,
 } from "lucide-react";
 import { useSettings } from "./Settings.tsx";
 import { useFileUpload, UploadedFile } from "../hooks/useFileUploads";
+import { apiClient, ApiError } from "../lib/api-client.ts";
+import { API_AGENT_PREFIX } from "../config.ts";
+import { toast } from "sonner";
 import { useSelectedAttachments } from "../hooks/SelectedAttachmentsContext.tsx";
 import {
   AttachmentBubble,
@@ -65,6 +70,13 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
   const { selected, clear } = useSelectedAttachments();
   const autoApproveLockRef = useRef<unknown>(null);
   const [isMCPLoading, setIsMCPLoading] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const [micSupported, setMicSupported] = useState(false);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const recordedChunksRef = useRef<Blob[]>([]);
+  const cancelRecordingRef = useRef(false);
 
   const {
     collections,
@@ -190,6 +202,180 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
 
     return () => media.removeEventListener("change", updateIsMobileDevice);
   }, []);
+
+  useEffect(() => {
+    const supported =
+      typeof navigator !== "undefined" &&
+      !!navigator.mediaDevices?.getUserMedia &&
+      typeof window.MediaRecorder !== "undefined";
+    setMicSupported(supported);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
+      mediaStreamRef.current = null;
+      mediaRecorderRef.current = null;
+    };
+  }, []);
+
+  const insertAtCursor = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const el = textRef.current;
+    setMessage((prev) => {
+      const start = el?.selectionStart ?? prev.length;
+      const end = el?.selectionEnd ?? prev.length;
+      const before = prev.slice(0, start);
+      const after = prev.slice(end);
+      const needsLeadingSpace = before.length > 0 && !/\s$/.test(before);
+      const needsTrailingSpace = after.length > 0 && !/^\s/.test(after);
+      const insertion =
+        (needsLeadingSpace ? " " : "") +
+        trimmed +
+        (needsTrailingSpace ? " " : "");
+      const next = before + insertion + after;
+      requestAnimationFrame(() => {
+        const caret = before.length + insertion.length;
+        if (el) {
+          el.focus();
+          try {
+            el.setSelectionRange(caret, caret);
+          } catch {
+            /* selection may fail if unmounted */
+          }
+        }
+      });
+      return next;
+    });
+  }, []);
+
+  const teardownRecording = useCallback(() => {
+    mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
+    mediaStreamRef.current = null;
+    mediaRecorderRef.current = null;
+    recordedChunksRef.current = [];
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    if (isRecording || isTranscribing || !micSupported) return;
+    if (thread?.isLoading || isMCPLoading) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaStreamRef.current = stream;
+      const candidates = [
+        "audio/webm;codecs=opus",
+        "audio/ogg;codecs=opus",
+        "audio/webm",
+        "audio/mp4",
+      ];
+      const mimeType = candidates.find((c) =>
+        typeof MediaRecorder.isTypeSupported === "function"
+          ? MediaRecorder.isTypeSupported(c)
+          : false,
+      );
+      const rec = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream);
+      recordedChunksRef.current = [];
+      rec.addEventListener("dataavailable", (e) => {
+        if (e.data && e.data.size > 0) recordedChunksRef.current.push(e.data);
+      });
+      mediaRecorderRef.current = rec;
+      cancelRecordingRef.current = false;
+      rec.start();
+      setIsRecording(true);
+    } catch {
+      teardownRecording();
+      setIsRecording(false);
+    }
+  }, [
+    isRecording,
+    isTranscribing,
+    micSupported,
+    thread?.isLoading,
+    isMCPLoading,
+    teardownRecording,
+  ]);
+
+  const finishRecording = useCallback(
+    async (cancelled: boolean) => {
+      const rec = mediaRecorderRef.current;
+      if (!rec) {
+        setIsRecording(false);
+        return;
+      }
+      const blob = await new Promise<Blob>((resolve) => {
+        const handle = () => {
+          const b = new Blob(recordedChunksRef.current, {
+            type: rec.mimeType || "audio/webm",
+          });
+          resolve(b);
+        };
+        rec.addEventListener("stop", handle, { once: true });
+        if (rec.state !== "inactive") {
+          try {
+            rec.stop();
+          } catch {
+            handle();
+          }
+        } else {
+          handle();
+        }
+      });
+      const mime = rec.mimeType || "audio/webm";
+      teardownRecording();
+      setIsRecording(false);
+
+      if (cancelled || blob.size === 0) return;
+
+      setIsTranscribing(true);
+      try {
+        const form = new FormData();
+        const ext = mime.includes("ogg")
+          ? "ogg"
+          : mime.includes("mp4")
+            ? "m4a"
+            : "webm";
+        form.append("audio", blob, `record.${ext}`);
+        const res = await apiClient.post<{ text: string }>(
+          `${API_AGENT_PREFIX}/stt/recognize`,
+          form,
+          { attachAuth: true, showError: false },
+        );
+        if (res?.text) insertAtCursor(res.text);
+        else {
+          toast.warning("Речь не распознана", {
+            description: "Попробуй ещё раз, говори чуть громче.",
+            richColors: true,
+          });
+        }
+      } catch (err) {
+        const detail =
+          err instanceof ApiError ? err.message : "Не удалось распознать речь";
+        toast.error("Распознавание не удалось", {
+          description: detail,
+          richColors: true,
+        });
+      } finally {
+        setIsTranscribing(false);
+      }
+    },
+    [teardownRecording, insertAtCursor],
+  );
+
+  const stopRecording = useCallback(() => {
+    if (!isRecording) return;
+    const cancelled = cancelRecordingRef.current;
+    cancelRecordingRef.current = false;
+    void finishRecording(cancelled);
+  }, [isRecording, finishRecording]);
+
+  const cancelRecording = useCallback(() => {
+    if (!isRecording) return;
+    cancelRecordingRef.current = true;
+    void finishRecording(true);
+  }, [isRecording, finishRecording]);
 
   const handleContinue = useCallback(
     async (type: "comment" | "approve") => {
@@ -385,8 +571,21 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
 
   return (
     <div className="bg-card w-full sticky bottom-0 p-5 pt-0 max-[900px]:p-0 z-9">
+      <div className="relative max-w-[900px] mx-auto">
+        <label
+          data-onboarding="autonomy-switch"
+          className="absolute -top-5 right-2 flex items-center gap-2 select-none text-[11px] text-muted-foreground leading-none z-20 bg-card/80 rounded px-1"
+        >
+          <span>Автономность</span>
+          <Switch
+            checked={settings.autoApprove ?? false}
+            onCheckedChange={(checked) =>
+              setSettings((prev) => ({ ...prev, autoApprove: checked }))
+            }
+          />
+        </label>
       <div
-        className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight max-w-[900px] mx-auto overflow-hidden"
+        className="relative p-4 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight overflow-hidden"
         onDragEnter={handleDragEnter}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
@@ -470,6 +669,54 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
             className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60"
           />
           <div className="flex flex-col items-end gap-1">
+            {micSupported && (
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  void startRecording();
+                }}
+                onMouseUp={(e) => {
+                  e.preventDefault();
+                  stopRecording();
+                }}
+                onMouseLeave={() => {
+                  if (isRecording) cancelRecording();
+                }}
+                onTouchStart={(e) => {
+                  e.preventDefault();
+                  void startRecording();
+                }}
+                onTouchEnd={(e) => {
+                  e.preventDefault();
+                  stopRecording();
+                }}
+                onTouchCancel={cancelRecording}
+                onContextMenu={(e) => e.preventDefault()}
+                disabled={
+                  thread?.isLoading || isMCPLoading || isTranscribing
+                }
+                title={
+                  isRecording
+                    ? "Отпустите, чтобы распознать"
+                    : "Зажмите и диктуйте"
+                }
+                aria-label="Голосовой ввод"
+                aria-pressed={isRecording}
+                className={[
+                  "w-9 h-9 p-0 rounded-full flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67 select-none",
+                  isRecording
+                    ? "bg-red-500/15 text-red-500 animate-pulse"
+                    : "text-foreground",
+                ].join(" ")}
+              >
+                {isTranscribing ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <Mic />
+                )}
+              </button>
+            )}
             <button
               type="button"
               onClick={handleSend}
@@ -485,18 +732,6 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
               <Send />
             </button>
           </div>
-          <label
-            data-onboarding="autonomy-switch"
-            className="absolute top-0 right-0 flex items-center gap-2 select-none text-[11px] text-muted-foreground leading-none"
-          >
-            <span>Автономность</span>
-            <Switch
-              checked={settings.autoApprove ?? false}
-              onCheckedChange={(checked) =>
-                setSettings((prev) => ({ ...prev, autoApprove: checked }))
-              }
-            />
-          </label>
         </div>
 
         {uploads.length > 0 && (
@@ -550,6 +785,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
             <CloseButton onClick={() => setEnlargedImage(null)}>×</CloseButton>
           </Overlay>
         )}
+      </div>
       </div>
     </div>
   );

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -233,7 +233,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
   // при первом рендере и при очистке
   useEffect(() => {
     autoResize();
-  }, [message]);
+  }, [message, isMobileDevice]);
 
   useEffect(() => {
     if (!window.matchMedia) return;
@@ -686,11 +686,99 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
     uploads.length === 0 &&
     !thread?.interrupt;
 
+  const renderInputActions = (className?: string) => (
+    <div
+      className={
+        className ??
+        (isRecording
+          ? "flex items-center gap-2"
+          : "flex flex-col items-end gap-1")
+      }
+    >
+      {isRecording ? (
+        <>
+          <button
+            type="button"
+            onClick={cancelRecording}
+            title="Отменить запись"
+            aria-label="Отменить запись"
+            className="w-9 h-9 p-0 rounded-full text-destructive hover:bg-destructive/10 flex items-center justify-center transition-colors cursor-pointer outline-hidden"
+          >
+            <X />
+          </button>
+          <button
+            type="button"
+            onClick={acceptRecording}
+            title="Готово"
+            aria-label="Готово"
+            className="w-9 h-9 p-0 rounded-full bg-red-500/15 text-red-500 animate-pulse flex items-center justify-center transition-colors cursor-pointer outline-hidden"
+          >
+            <Check />
+          </button>
+        </>
+      ) : isTranscribing ? (
+        <button
+          type="button"
+          disabled
+          title="Распознавание…"
+          aria-label="Распознавание"
+          className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center outline-hidden"
+        >
+          <Loader2 className="animate-spin" />
+        </button>
+      ) : showMicButton ? (
+        <button
+          type="button"
+          onClick={() => void startRecording()}
+          title="Голосовой ввод"
+          aria-label="Голосовой ввод"
+          className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden"
+        >
+          <Mic />
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={
+            thread?.isLoading || isMCPLoading || !message.trim() || isUploading
+          }
+          title="Отправить"
+          className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
+        >
+          <Send />
+        </button>
+      )}
+    </div>
+  );
+
+  const renderAttachmentButton = (className?: string) => (
+    <button
+      data-onboarding="attachments-btn"
+      type="button"
+      onClick={() => fileInputRef.current?.click()}
+      disabled={thread?.isLoading || isMCPLoading}
+      title="Добавить вложения"
+      className={
+        className ??
+        "w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
+      }
+    >
+      <Paperclip />
+    </button>
+  );
+
   return (
     <div className="bg-card w-full sticky bottom-0 p-5 pt-0 max-[900px]:p-0 z-9">
       {isDragging && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/70 backdrop-blur-sm pointer-events-none print:hidden animate-in fade-in duration-150">
-          <div className="m-6 px-8 py-10 rounded-2xl border-2 border-dashed border-primary bg-card/95 dark:bg-input/95 shadow-xl text-foreground text-base font-medium">
+        <div
+          className={[
+            "fixed inset-0 z-[100] flex items-center justify-center bg-background/70 backdrop-blur-sm pointer-events-none print:hidden animate-in fade-in duration-150",
+            settings.sideBarOpen ? "min-[900px]:left-[200px]" : "",
+          ].join(" ")}
+        >
+          <div className="m-6 flex flex-col items-center gap-4 px-8 py-10 text-foreground text-base font-medium">
+            <Files className="size-14 text-foreground/90" />
             Отпустите, чтобы прикрепить файлы
           </div>
         </div>
@@ -705,7 +793,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
             multiple
             disabled={thread?.isLoading || isMCPLoading}
           />
-          <div className="flex flex-col items-center gap-1">
+          <div className="flex flex-col items-center gap-1 self-start">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -741,16 +829,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <button
-              data-onboarding="attachments-btn"
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={thread?.isLoading || isMCPLoading}
-              title="Добавить вложения"
-              className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
-            >
-              <Paperclip />
-            </button>
+            <div className="max-[900px]:hidden">{renderAttachmentButton()}</div>
           </div>
 
           <textarea
@@ -761,75 +840,18 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
                 : "Введите вашу задачу…"
             }
             ref={textRef}
+            rows={isMobileDevice ? 1 : 2}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
             disabled={thread?.isLoading || isMCPLoading}
-            className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60"
+            className="flex-1 min-h-[76px] max-h-[200px] resize-none font-sans p-3 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60 max-[900px]:min-h-[60px] max-[900px]:h-[60px]"
           />
-          <div className="self-end mb-1 shrink-0">
+          <div className="self-end mb-1 shrink-0 max-[900px]:hidden">
             <ModelPicker disabled={thread?.isLoading || isMCPLoading} />
           </div>
-          <div className="flex flex-col items-end gap-1">
-            {isRecording ? (
-              <>
-                <button
-                  type="button"
-                  onClick={cancelRecording}
-                  title="Отменить запись"
-                  aria-label="Отменить запись"
-                  className="w-9 h-9 p-0 rounded-full text-destructive hover:bg-destructive/10 flex items-center justify-center transition-colors cursor-pointer outline-hidden"
-                >
-                  <X />
-                </button>
-                <button
-                  type="button"
-                  onClick={acceptRecording}
-                  title="Готово"
-                  aria-label="Готово"
-                  className="w-9 h-9 p-0 rounded-full bg-red-500/15 text-red-500 animate-pulse flex items-center justify-center transition-colors cursor-pointer outline-hidden"
-                >
-                  <Check />
-                </button>
-              </>
-            ) : isTranscribing ? (
-              <button
-                type="button"
-                disabled
-                title="Распознавание…"
-                aria-label="Распознавание"
-                className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center outline-hidden"
-              >
-                <Loader2 className="animate-spin" />
-              </button>
-            ) : showMicButton ? (
-              <button
-                type="button"
-                onClick={() => void startRecording()}
-                title="Голосовой ввод"
-                aria-label="Голосовой ввод"
-                className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden"
-              >
-                <Mic />
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={handleSend}
-                disabled={
-                  thread?.isLoading ||
-                  isMCPLoading ||
-                  !message.trim() ||
-                  isUploading
-                }
-                title="Отправить"
-                className="w-9 h-9 p-0 rounded-full text-foreground flex items-center justify-center transition-colors cursor-pointer outline-hidden disabled:opacity-67"
-              >
-                <Send />
-              </button>
-            )}
-          </div>
+          <div className="max-[900px]:hidden">{renderInputActions()}</div>
           <label
             data-onboarding="autonomy-switch"
             className="absolute top-0 right-0 flex items-center gap-2 select-none text-[11px] text-muted-foreground leading-none"
@@ -842,6 +864,13 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
               }
             />
           </label>
+        </div>
+        <div className="hidden max-[900px]:flex items-center justify-between gap-2">
+        {renderAttachmentButton()}
+          <div className="flex items-center gap-2 shrink-0">
+          <ModelPicker disabled={thread?.isLoading || isMCPLoading} />
+            {renderInputActions("flex items-center gap-2")}
+          </div>
         </div>
 
         {uploads.length > 0 && (

--- a/front/src/components/ModelPicker.tsx
+++ b/front/src/components/ModelPicker.tsx
@@ -1,0 +1,114 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Check, ChevronDown, Loader2 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { apiClient } from "@/lib/api-client";
+import { API_AGENT_PREFIX } from "@/config.ts";
+import { useAuth } from "@/components/providers/auth.tsx";
+import type { LLMResponse } from "@/components/settings-page/forms/types";
+
+const llmLabel = (llm: LLMResponse): string => llm.name || llm.model_id;
+
+const ModelPicker: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
+  const { user, refreshUser } = useAuth();
+  const [llms, setLlms] = useState<LLMResponse[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    apiClient
+      .get<LLMResponse[]>(`${API_AGENT_PREFIX}/llms`)
+      .then((data) => {
+        if (cancelled) return;
+        setLlms(data);
+      })
+      .catch(() => {
+        /* handled globally */
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const currentLlm = llms.find((llm) => llm.id === user?.llm_id) ?? null;
+  const currentLabel = currentLlm
+    ? llmLabel(currentLlm)
+    : loading
+      ? "Загрузка…"
+      : "Модель не выбрана";
+
+  const selectLlm = useCallback(
+    async (llmId: string) => {
+      if (llmId === user?.llm_id || saving) return;
+      setSaving(true);
+      try {
+        await apiClient.patch(`${API_AGENT_PREFIX}/auth/users/me`, {
+          llm_id: llmId,
+        });
+        await refreshUser();
+      } catch {
+        /* handled globally */
+      } finally {
+        setSaving(false);
+      }
+    },
+    [user?.llm_id, saving, refreshUser],
+  );
+
+  if (!user) return null;
+  if (!loading && llms.length === 0) return null;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled || saving}
+          title="Выбрать модель"
+          className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors cursor-pointer outline-none disabled:opacity-60 max-w-[180px]"
+        >
+          {saving ? (
+            <Loader2 className="size-3.5 animate-spin shrink-0" />
+          ) : null}
+          <span className="truncate">{currentLabel}</span>
+          <ChevronDown className="size-3.5 shrink-0 opacity-70" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6} className="min-w-[240px]">
+        {llms.map((llm) => {
+          const isActive = llm.id === user.llm_id;
+          const label = llmLabel(llm);
+          return (
+            <DropdownMenuItem
+              key={llm.id}
+              onSelect={() => void selectLlm(llm.id)}
+              className="flex items-start gap-2 py-2 cursor-pointer"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium truncate">{label}</div>
+                <div className="text-xs text-muted-foreground truncate">
+                  {llm.model_id}
+                </div>
+              </div>
+              {isActive && (
+                <Check className="size-4 text-primary mt-0.5 shrink-0" />
+              )}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default ModelPicker;

--- a/front/src/components/Sidebar.tsx
+++ b/front/src/components/Sidebar.tsx
@@ -736,19 +736,6 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
           </div>
         )}
 
-        <div
-          className={[
-            "flex items-center p-2 text-sm rounded-lg cursor-pointer hover:bg-muted/50",
-            location.pathname === "/memories"
-              ? "bg-accent text-accent-foreground"
-              : "",
-          ].join(" ")}
-          onClick={handleMemories}
-        >
-          <Brain size={20} className="mr-2" />
-          Факты о вас
-        </div>
-
         <hr className="my-3 border-border/60" />
 
         {/* Список чатов (LangGraph threads.search / search_threads) */}
@@ -954,6 +941,10 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                   <User className="mr-2 h-4 w-4" />
                   Профиль
                 </DropdownMenuItem> */}
+                <DropdownMenuItem onSelect={handleMemories}>
+                  <Brain className="mr-2 h-4 w-4" />
+                  Факты о вас
+                </DropdownMenuItem>
                 <DropdownMenuItem onSelect={handleSettings}>
                   <SettingsIcon className="mr-2 h-4 w-4" />
                   Настройки

--- a/front/src/components/Sidebar.tsx
+++ b/front/src/components/Sidebar.tsx
@@ -65,6 +65,36 @@ interface SidebarProps {
   onNewChat: () => void;
 }
 
+const LAST_SEEN_STORAGE_KEY = "sidebar_thread_last_seen_v1";
+
+const readLastSeenFromStorage = (): Record<string, string> => {
+  try {
+    const raw = localStorage.getItem(LAST_SEEN_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const result: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string") result[k] = v;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+};
+
+const getThreadStatus = (t: Thread): string | undefined => {
+  const s = (t as unknown as { status?: unknown }).status;
+  return typeof s === "string" ? s : undefined;
+};
+
+const getThreadUpdatedAt = (t: Thread): string | undefined => {
+  const u = (t as unknown as { updated_at?: unknown }).updated_at;
+  return typeof u === "string" ? u : undefined;
+};
+
 const SidebarComponent = ({ onNewChat }: SidebarProps) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -99,6 +129,25 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
   const [threadsHasMore, setThreadsHasMore] = useState(false);
   const [threadsRefreshTick, setThreadsRefreshTick] = useState(0);
   const [typedTitles, setTypedTitles] = useState<Record<string, string>>({});
+  const [lastSeen, setLastSeen] = useState<Record<string, string>>(() =>
+    readLastSeenFromStorage(),
+  );
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LAST_SEEN_STORAGE_KEY, JSON.stringify(lastSeen));
+    } catch {
+      /* storage unavailable — ignore */
+    }
+  }, [lastSeen]);
+
+  const markThreadSeen = (threadId: string, updatedAt: string | undefined) => {
+    if (!updatedAt) return;
+    setLastSeen((prev) => {
+      if (prev[threadId] === updatedAt) return prev;
+      return { ...prev, [threadId]: updatedAt };
+    });
+  };
   const typingTimersRef = useRef<Record<string, number>>({});
   const prevThreadsRef = useRef<Map<string, string>>(new Map());
   const hasLoadedThreadsOnceRef = useRef(false);
@@ -150,6 +199,17 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
     };
   }, []);
 
+  // Keep the currently-open thread marked as seen at its latest updated_at
+  // whenever the sidebar refreshes. If a user is viewing a thread and new
+  // activity lands, they see it live — so the dot should never appear on
+  // the active thread.
+  useEffect(() => {
+    if (!activeThreadId) return;
+    const active = threads.find((t) => t.thread_id === activeThreadId);
+    if (!active) return;
+    markThreadSeen(activeThreadId, getThreadUpdatedAt(active));
+  }, [activeThreadId, threads]);
+
   useEffect(() => {
     hasLoadedThreadsOnceRef.current = false;
     prevThreadsRef.current = new Map();
@@ -191,7 +251,7 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
     setThreadsMoreError(null);
 
     const searchPromise = langGraphClient.threads.search({
-      select: ["thread_id", "metadata"],
+      select: ["thread_id", "metadata", "status", "updated_at"],
       metadata: {
         graph_id: currentGraphId,
       },
@@ -240,6 +300,23 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
           }
           prevThreadsRef.current = next;
           hasLoadedThreadsOnceRef.current = true;
+          // On the first load for this graph, seed lastSeen for any thread we
+          // don't have an entry for yet — existing threads shouldn't all light
+          // up as unread. Threads that appear on *subsequent* loads stay
+          // unseeded, so genuinely-new activity shows a dot.
+          setLastSeen((prev) => {
+            let changed = false;
+            const merged = { ...prev };
+            for (const t of result) {
+              if (t.thread_id in merged) continue;
+              const updatedAt = getThreadUpdatedAt(t);
+              if (updatedAt) {
+                merged[t.thread_id] = updatedAt;
+                changed = true;
+              }
+            }
+            return changed ? merged : prev;
+          });
           setThreads(result);
           setThreadsTotal(total);
           setThreadsHasMore(hasMore);
@@ -317,7 +394,7 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
     try {
       const offset = threads.length;
       const result = await langGraphClient.threads.search({
-        select: ["thread_id", "metadata"],
+        select: ["thread_id", "metadata", "status", "updated_at"],
         metadata: {
           graph_id: currentGraphId,
         },
@@ -359,6 +436,22 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
         nextPrev.set(t.thread_id, rawTitle);
       }
       prevThreadsRef.current = nextPrev;
+
+      // Pagination brings in older threads the user may have never opened.
+      // Seed lastSeen so they don't all flash as unread.
+      setLastSeen((prev) => {
+        let changed = false;
+        const merged = { ...prev };
+        for (const t of toAdd) {
+          if (t.thread_id in merged) continue;
+          const updatedAt = getThreadUpdatedAt(t);
+          if (updatedAt) {
+            merged[t.thread_id] = updatedAt;
+            changed = true;
+          }
+        }
+        return changed ? merged : prev;
+      });
 
       if (threadsTotal === null) {
         // Fallback when total is unknown: stop only when page is short.
@@ -445,6 +538,8 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
 
   const handleOpenThread = (threadId: string) => {
     closeSidebarOnMobile();
+    const opened = threads.find((t) => t.thread_id === threadId);
+    markThreadSeen(threadId, getThreadUpdatedAt(opened ?? ({} as Thread)));
     navigate(`/threads/${threadId}`);
   };
 
@@ -626,6 +721,36 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
 
         <hr className="my-3 border-border/60" />
 
+        {ragEnabled() && (
+          <div
+            className={[
+              "flex items-center p-2 text-sm rounded-lg cursor-pointer hover:bg-muted/50",
+              location.pathname === "/rag"
+                ? "bg-accent text-accent-foreground"
+                : "",
+            ].join(" ")}
+            onClick={handleRag}
+          >
+            <Files size={20} className="mr-2" />
+            Документы
+          </div>
+        )}
+
+        <div
+          className={[
+            "flex items-center p-2 text-sm rounded-lg cursor-pointer hover:bg-muted/50",
+            location.pathname === "/memories"
+              ? "bg-accent text-accent-foreground"
+              : "",
+          ].join(" ")}
+          onClick={handleMemories}
+        >
+          <Brain size={20} className="mr-2" />
+          Факты о вас
+        </div>
+
+        <hr className="my-3 border-border/60" />
+
         {/* Список чатов (LangGraph threads.search / search_threads) */}
         {user && (
           <div className="flex flex-col flex-1 min-h-0">
@@ -669,6 +794,20 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                     const isActive = activeThreadId === t.thread_id;
                     const meta = getThreadMeta(t);
                     const isTelegramThread = meta.channel === "telegram";
+                    const status = getThreadStatus(t);
+                    const updatedAt = getThreadUpdatedAt(t);
+                    const seenAt = lastSeen[t.thread_id];
+                    const isUnseen =
+                      typeof updatedAt === "string" &&
+                      (seenAt === undefined || updatedAt > seenAt);
+                    const needsInput =
+                      !isActive && status === "interrupted" && isUnseen;
+                    const hasUpdate = !isActive && !needsInput && isUnseen;
+                    const indicatorTitle = needsInput
+                      ? "Ожидает вашего ответа"
+                      : hasUpdate
+                        ? "Новое обновление"
+                        : undefined;
 
                     return (
                       <div
@@ -692,7 +831,28 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                             />
                           </span>
                         )}
-                        <span className="flex-1 min-w-0 truncate">
+                        {(needsInput || hasUpdate) && (
+                          <span
+                            className="shrink-0 flex items-center justify-center"
+                            title={indicatorTitle}
+                            aria-label={indicatorTitle}
+                          >
+                            <span
+                              className={[
+                                "inline-block h-2 w-2 rounded-full",
+                                needsInput
+                                  ? "bg-amber-500 animate-pulse"
+                                  : "bg-sky-500",
+                              ].join(" ")}
+                            />
+                          </span>
+                        )}
+                        <span
+                          className={[
+                            "flex-1 min-w-0 truncate",
+                            needsInput || hasUpdate ? "font-medium" : "",
+                          ].join(" ")}
+                        >
                           {displayTitle}
                         </span>
                         <DropdownMenu>
@@ -794,16 +954,6 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                   <User className="mr-2 h-4 w-4" />
                   Профиль
                 </DropdownMenuItem> */}
-                {ragEnabled() && (
-                  <DropdownMenuItem onSelect={handleRag}>
-                    <Files className="mr-2 h-4 w-4" />
-                    Документы
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuItem onSelect={handleMemories}>
-                  <Brain className="mr-2 h-4 w-4" />
-                  Факты о вас
-                </DropdownMenuItem>
                 <DropdownMenuItem onSelect={handleSettings}>
                   <SettingsIcon className="mr-2 h-4 w-4" />
                   Настройки

--- a/front/src/components/Sidebar.tsx
+++ b/front/src/components/Sidebar.tsx
@@ -66,6 +66,8 @@ interface SidebarProps {
 }
 
 const LAST_SEEN_STORAGE_KEY = "sidebar_thread_last_seen_v1";
+const THREADS_PAGE_SIZE = 50;
+const THREADS_POLL_INTERVAL_MS = 20_000;
 
 const readLastSeenFromStorage = (): Record<string, string> => {
   try {
@@ -101,7 +103,6 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
   const { settings, setSettings } = useSettings();
   const { isDark } = useTheme();
   const { user, logout, token } = useAuth();
-  const THREADS_PAGE_SIZE = 50;
   const SIDEBAR_WIDTH = 270;
 
   const activeThreadId = useMemo(() => {
@@ -229,6 +230,21 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
   }, []);
 
   useEffect(() => {
+    if (!settings.sideBarOpen || !langGraphClient) return;
+
+    const intervalId = window.setInterval(() => {
+      setThreadsRefreshTick((x) => x + 1);
+    }, THREADS_POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(intervalId);
+  }, [
+    currentGraphId,
+    langGraphClient,
+    settings.sideBarOpen,
+    THREADS_POLL_INTERVAL_MS,
+  ]);
+
+  useEffect(() => {
     if (!settings.sideBarOpen) return;
     if (!langGraphClient) {
       setThreads([]);
@@ -343,10 +359,8 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
             rawTitle.length > 0;
 
           if (isNewThread || titleJustAppeared) {
-            const lastIdPart = t.thread_id.split("/").filter(Boolean).at(-1);
-            const shortId = (lastIdPart ?? t.thread_id).slice(0, 4);
             const displayTitle =
-              rawTitle.length > 0 ? rawTitle : `Новый чат - ${shortId}`;
+              rawTitle.length > 0 ? rawTitle : `Новый диалог`;
             startTypingTitle(t.thread_id, displayTitle);
           }
         }
@@ -1094,29 +1108,6 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
-      {/* Opener button */}
-      {/* <div className="fixed top-4 left-5 z-[200] bg-transparent border-0 flex items-center text-card-foreground transition-[left] duration-300 ease-in-out print:[&>svg]:hidden">
-        <div
-          className="h-10 bg-cover transition-[width] duration-300 ease-in-out cursor-pointer"
-          style={{
-            width: settings.sideBarOpen ? 156 : 40,
-            backgroundImage: `url(${isDark ? LogoImage : LogoWhiteImage})`,
-          }}
-          onClick={() => {
-            if (window.innerWidth >= 900) {
-              handleNewChat();
-            }
-          }}
-        />
-        <ChevronRight
-          onClick={toggle}
-          style={{
-            transform: settings.sideBarOpen ? "rotate(180deg)" : "rotate(0)",
-            marginLeft: "0.5rem",
-          }}
-        />
-      </div> */}
     </>
   );
 };

--- a/front/src/config.ts
+++ b/front/src/config.ts
@@ -1,9 +1,15 @@
+interface RuntimeSttConfig {
+  enabled: boolean;
+  runtime: "salute" | null;
+}
+
 interface RuntimeConfig {
   baseUrl?: string;
   basePath?: string;
   apiBasePath?: string;
   apiAgentBasePath?: string;
   skipOnboarding?: boolean;
+  stt?: RuntimeSttConfig;
 }
 
 declare global {
@@ -99,6 +105,7 @@ export const API_BASE_URL =
 export const API_PREFIX = API_BASE_URL;
 export const API_AGENT_PREFIX = `${API_BASE_URL}/agent`;
 export const SKIP_ONBOARDING = runtimeConfig.skipOnboarding === true;
+export const BACKEND_STT_ENABLED = runtimeConfig.stt?.enabled === true;
 
 export const TOOL_MAP = {
   lean_canvas: "Агент по созданию Lean Canvas",

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -62,6 +62,10 @@ export default defineConfig(({ mode }) => {
                 changeOrigin: true,
                 rewrite: (path) => path.replace(/^\/api/, ""),
               },
+              "/app-config.js": {
+                target: "http://localhost:9090/",
+                changeOrigin: true,
+              },
             },
             port: 3000,
           }


### PR DESCRIPTION
## Summary
- **Voice input (press-to-talk).** `POST /api/agent/stt/recognize` transcodes uploaded audio to 16 kHz PCM16 via pydub and relays it to SaluteSpeech `/speech:recognize`. Frontend adds a mic button in the input area (`MediaRecorder` + `getUserMedia`); hold to record, release to insert the transcript at the caret. Requires `SALUTE_SPEECH` / `SALUTE_SCOPE` env.
- **Model picker in the input area.** Claude-style compact dropdown next to the mic/send button showing the current LLM name; opens a list of user-accessible models from `GET /api/llms`. Selecting writes `llm_id` via `PATCH /api/auth/users/me` and refreshes the user — the next message uses the new model (existing `LLMManager.resolve_by_id` flow, no backend changes).
- **Sidebar thread status indicators.** Amber pulsing dot when a thread is interrupted (awaiting user input); blue dot when a thread has activity newer than the locally-stored `lastSeen` timestamp. Both indicators clear after the user opens the thread. State persisted in `localStorage`, auto-seeded on first load so existing threads don't flash.
- **Input UX.** Window-wide drag-and-drop file uploads (drop anywhere on the page, full-screen overlay while dragging) and clipboard paste; floating "scroll to bottom" button that appears once the user has scrolled up more than one viewport.
- **Layout.** Moved the "Автономность" toggle above the input frame so it no longer collides with the mic button.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Manual: voice input end-to-end against SaluteSpeech
- [x] Manual: sidebar indicators on interrupted / newly-updated threads clear after opening the thread
- [x] Manual: drag-and-drop from outside the browser window, clipboard paste of screenshots
- [x] Manual: switch model via the input-area picker, confirm the next response uses the selected model
- [x] Verify in a clean environment without `SALUTE_SPEECH` → mic shows configuration toast (no user-facing crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)