### PR TITLE
Feature/projects

### DIFF
--- a/backend/giga_agent/agents/giga_agent.py
+++ b/backend/giga_agent/agents/giga_agent.py
@@ -7,6 +7,7 @@ from giga_agent.modules.deep_research import DeepResearchModule
 from giga_agent.modules.github import GitHubModule
 from giga_agent.modules.image import ImageModule
 from giga_agent.modules.io import IOModule
+from giga_agent.modules.projects import ProjectsModule
 from giga_agent.modules.rag import RagModule
 from giga_agent.modules.repl import ReplModule
 from giga_agent.modules.scraper import ScraperModule
@@ -25,6 +26,7 @@ class GigaAgent(BaseAgent):
             ImageModule(),
             AnalyzeImagesModule(),
             IOModule(),
+            ProjectsModule(),
             ScraperModule(),
             SearchModule(),
             RagModule(),

--- a/backend/giga_agent/models/__init__.py
+++ b/backend/giga_agent/models/__init__.py
@@ -134,6 +134,13 @@ from giga_agent.models.skill import (
     SkillUpdate,
     SkillRepository,
 )
+from giga_agent.models.project import (
+    Project,
+    ProjectCreate,
+    ProjectUpdate,
+    ProjectResponse,
+    ProjectRepository,
+)
 
 from giga_agent.models.channel import (
     ChannelBot,
@@ -265,6 +272,12 @@ __all__ = [
     "SkillCreate",
     "SkillUpdate",
     "SkillRepository",
+    # Projects
+    "Project",
+    "ProjectCreate",
+    "ProjectUpdate",
+    "ProjectResponse",
+    "ProjectRepository",
     # Channels
     "ChannelBot",
     "ChannelThread",

--- a/backend/giga_agent/models/migrations/2026_05_27_1200-9a4f8d2e1c3b_add_projects_table.py
+++ b/backend/giga_agent/models/migrations/2026_05_27_1200-9a4f8d2e1c3b_add_projects_table.py
@@ -1,0 +1,61 @@
+"""add_projects_table
+
+Revision ID: 9a4f8d2e1c3b
+Revises: 7e1f4c2a9b15
+Create Date: 2026-05-27 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9a4f8d2e1c3b"
+down_revision: Union[str, None] = "7e1f4c2a9b15"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "core_projects",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("owner_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.String(length=1024), nullable=True),
+        sa.Column("instructions", sa.Text(), nullable=True),
+        sa.Column("collection_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["owner_id"], ["core_users.id"]),
+        sa.ForeignKeyConstraint(
+            ["collection_id"], ["core_rag_collections.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("owner_id", "name", name="uq_project_owner_name"),
+    )
+    with op.batch_alter_table("core_projects", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_core_projects_id"), ["id"], unique=False)
+        batch_op.create_index(
+            batch_op.f("ix_core_projects_owner_id"), ["owner_id"], unique=False
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("core_projects", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_core_projects_owner_id"))
+        batch_op.drop_index(batch_op.f("ix_core_projects_id"))
+
+    op.drop_table("core_projects")

--- a/backend/giga_agent/models/migrations/2026_06_17_1200-9a4f8d2e1c3b_add_projects_table.py
+++ b/backend/giga_agent/models/migrations/2026_06_17_1200-9a4f8d2e1c3b_add_projects_table.py
@@ -7,13 +7,12 @@ Create Date: 2026-05-27 12:00:00.000000
 """
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "9a4f8d2e1c3b"
-down_revision: Union[str, None] = "7e1f4c2a9b15"
+down_revision: Union[str, None] = "ed56338cb9b2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/giga_agent/models/project.py
+++ b/backend/giga_agent/models/project.py
@@ -1,5 +1,7 @@
 import uuid
 from datetime import datetime
+
+from cashews import cache
 from pydantic import BaseModel, Field
 from sqlalchemy import (
     DateTime,
@@ -77,6 +79,58 @@ class ProjectRepository:
     def __init__(self, db: AsyncSession):
         self.db = db
 
+    @staticmethod
+    def cache_key(project_id: uuid.UUID) -> str:
+        return f"project:ctx:{project_id}"
+
+    @staticmethod
+    async def get_from_cache(project_id: uuid.UUID) -> ProjectResponse | None:
+        cached = await cache.get(ProjectRepository.cache_key(project_id))
+        if cached is None:
+            return None
+        return ProjectResponse.model_validate(cached)
+
+    @staticmethod
+    async def invalidate_cache(project_id: uuid.UUID) -> None:
+        await cache.delete(ProjectRepository.cache_key(project_id))
+
+    async def get_by_id_response(
+        self,
+        project_id: uuid.UUID,
+        *,
+        use_cache: bool = True,
+    ) -> ProjectResponse | None:
+        if use_cache:
+            cached = await self.get_from_cache(project_id)
+            if cached is not None:
+                return cached
+
+        project = await self.get_by_id(project_id)
+        if project is None:
+            return None
+
+        response = ProjectResponse.model_validate(project)
+        await cache.set(
+            self.cache_key(project_id),
+            response.model_dump(mode="json"),
+            expire="5m",
+        )
+        return response
+
+    @classmethod
+    async def get_cached_or_db_for_owner(
+        cls,
+        project_id: uuid.UUID,
+        owner_id: uuid.UUID,
+        *,
+        session: AsyncSession,
+    ) -> ProjectResponse | None:
+        """Resolve a project for ``owner_id``, serving from cashews when warm."""
+        response = await cls(session).get_by_id_response(project_id)
+        if response is None or response.owner_id != owner_id:
+            return None
+        return response
+
     async def get_by_id(self, project_id: uuid.UUID) -> Project | None:
         result = await self.db.execute(select(Project).where(Project.id == project_id))
         return result.scalar_one_or_none()
@@ -137,11 +191,14 @@ class ProjectRepository:
                 setattr(project, key, value)
         await self.db.commit()
         await self.db.refresh(project)
+        await self.invalidate_cache(project.id)
         return project
 
     async def delete(self, project: Project) -> None:
+        project_id = project.id
         await self.db.delete(project)
         await self.db.commit()
+        await self.invalidate_cache(project_id)
 
     async def delete_by_owner(self, owner_id: uuid.UUID) -> int:
         result = await self.db.execute(

--- a/backend/giga_agent/models/project.py
+++ b/backend/giga_agent/models/project.py
@@ -1,0 +1,151 @@
+import uuid
+from datetime import datetime
+from pydantic import BaseModel, Field
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+    Uuid,
+    UniqueConstraint,
+    delete,
+    select,
+)
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from giga_agent.core.db import Base
+
+
+class Project(Base):
+    """Проект — группа тредов с общими инструкциями и knowledge-коллекцией."""
+
+    __tablename__ = "core_projects"
+    __table_args__ = (
+        UniqueConstraint("owner_id", "name", name="uq_project_owner_name"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, primary_key=True, index=True, default=uuid.uuid4
+    )
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("core_users.id"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    instructions: Mapped[str | None] = mapped_column(Text, nullable=True)
+    collection_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("core_rag_collections.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), server_default=func.now()
+    )
+
+
+class ProjectCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    description: str | None = Field(None, max_length=1024)
+    instructions: str | None = None
+
+
+class ProjectUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=128)
+    description: str | None = Field(None, max_length=1024)
+    instructions: str | None = None
+
+
+class ProjectResponse(BaseModel):
+    id: uuid.UUID
+    owner_id: uuid.UUID
+    name: str
+    description: str | None = None
+    instructions: str | None = None
+    collection_id: uuid.UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ProjectRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_by_id(self, project_id: uuid.UUID) -> Project | None:
+        result = await self.db.execute(select(Project).where(Project.id == project_id))
+        return result.scalar_one_or_none()
+
+    async def get_for_owner(
+        self, project_id: uuid.UUID, owner_id: uuid.UUID
+    ) -> Project | None:
+        result = await self.db.execute(
+            select(Project).where(
+                Project.id == project_id, Project.owner_id == owner_id
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_owner(self, owner_id: uuid.UUID) -> list[Project]:
+        result = await self.db.execute(
+            select(Project)
+            .where(Project.owner_id == owner_id)
+            .order_by(Project.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def create(
+        self,
+        *,
+        owner_id: uuid.UUID,
+        name: str,
+        description: str | None = None,
+        instructions: str | None = None,
+        collection_id: uuid.UUID | None = None,
+    ) -> Project | None:
+        """Create a project. Returns None on duplicate owner+name."""
+        project = Project(
+            owner_id=owner_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            collection_id=collection_id,
+        )
+        self.db.add(project)
+        try:
+            await self.db.commit()
+        except IntegrityError as e:
+            await self.db.rollback()
+            details = str(getattr(e, "orig", e))
+            if (
+                "uq_project_owner_name" in details
+                or "core_projects.owner_id, core_projects.name" in details
+            ):
+                return None
+            raise
+        await self.db.refresh(project)
+        return project
+
+    async def update(self, project: Project, **kwargs) -> Project:
+        for key, value in kwargs.items():
+            if value is not None and hasattr(project, key):
+                setattr(project, key, value)
+        await self.db.commit()
+        await self.db.refresh(project)
+        return project
+
+    async def delete(self, project: Project) -> None:
+        await self.db.delete(project)
+        await self.db.commit()
+
+    async def delete_by_owner(self, owner_id: uuid.UUID) -> int:
+        result = await self.db.execute(
+            delete(Project).where(Project.owner_id == owner_id)
+        )
+        await self.db.commit()
+        return int(result.rowcount or 0)

--- a/backend/giga_agent/modules/projects/__init__.py
+++ b/backend/giga_agent/modules/projects/__init__.py
@@ -1,0 +1,3 @@
+from giga_agent.modules.projects.module import ProjectsModule
+
+__all__ = ["ProjectsModule"]

--- a/backend/giga_agent/modules/projects/api.py
+++ b/backend/giga_agent/modules/projects/api.py
@@ -153,14 +153,16 @@ async def delete_project(
     collection_id = project.collection_id
     await repo.delete(project)
     if collection_id is not None:
+        # Imported here to avoid a cycle (rag.api → projects → rag.api).
+        from giga_agent.modules.rag.api.collections import delete_collection
+
         try:
             collections = RagCollectionsRepository(db)
             collection = await collections.get_by_id(
                 owner_id=current_user.id, collection_id=collection_id
             )
             if collection is not None:
-                await db.delete(collection)
-                await db.commit()
+                await delete_collection(db=db, collection=collection)
         except Exception:
             logger.exception("Failed to delete project-backed RAG collection")
     return None

--- a/backend/giga_agent/modules/projects/api.py
+++ b/backend/giga_agent/modules/projects/api.py
@@ -1,0 +1,98 @@
+"""REST API endpoints for Projects."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from giga_agent.core.db import get_session
+from giga_agent.models.project import (
+    ProjectCreate,
+    ProjectRepository,
+    ProjectResponse,
+    ProjectUpdate,
+)
+from giga_agent.models.users import UserShort
+from giga_agent.modules.auth.api import get_current_active_user
+
+router = APIRouter(tags=["projects"])
+
+
+@router.get("/", response_model=list[ProjectResponse])
+async def list_projects(
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    repo = ProjectRepository(db)
+    projects = await repo.list_by_owner(current_user.id)
+    return [ProjectResponse.model_validate(p) for p in projects]
+
+
+@router.post("/", response_model=ProjectResponse, status_code=201)
+async def create_project(
+    payload: ProjectCreate,
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    repo = ProjectRepository(db)
+    project = await repo.create(
+        owner_id=current_user.id,
+        name=payload.name,
+        description=payload.description,
+        instructions=payload.instructions,
+    )
+    if project is None:
+        raise HTTPException(
+            status_code=409, detail="Project with this name already exists"
+        )
+    return ProjectResponse.model_validate(project)
+
+
+@router.get("/{project_id}", response_model=ProjectResponse)
+async def get_project(
+    project_id: uuid.UUID,
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    repo = ProjectRepository(db)
+    project = await repo.get_for_owner(project_id, current_user.id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return ProjectResponse.model_validate(project)
+
+
+@router.patch("/{project_id}", response_model=ProjectResponse)
+async def update_project(
+    project_id: uuid.UUID,
+    payload: ProjectUpdate,
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    repo = ProjectRepository(db)
+    project = await repo.get_for_owner(project_id, current_user.id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    updated = await repo.update(
+        project,
+        name=payload.name,
+        description=payload.description,
+        instructions=payload.instructions,
+    )
+    return ProjectResponse.model_validate(updated)
+
+
+@router.delete("/{project_id}", status_code=204)
+async def delete_project(
+    project_id: uuid.UUID,
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    repo = ProjectRepository(db)
+    project = await repo.get_for_owner(project_id, current_user.id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await repo.delete(project)
+    return None

--- a/backend/giga_agent/modules/projects/api.py
+++ b/backend/giga_agent/modules/projects/api.py
@@ -9,16 +9,54 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from giga_agent.core.db import get_session
+from giga_agent.core.logging import get_logger
 from giga_agent.models.project import (
     ProjectCreate,
     ProjectRepository,
     ProjectResponse,
     ProjectUpdate,
 )
+from giga_agent.models.rag import RagCollectionsRepository
 from giga_agent.models.users import UserShort
 from giga_agent.modules.auth.api import get_current_active_user
 
+logger = get_logger(__name__)
+
 router = APIRouter(tags=["projects"])
+
+
+def _project_collection_name(project_id: uuid.UUID) -> str:
+    return f"__project_{project_id}__"
+
+
+async def _try_create_project_collection(
+    *,
+    user: UserShort,
+    db: AsyncSession,
+    project_id: uuid.UUID,
+) -> uuid.UUID | None:
+    """Best-effort creation of a backing RAG collection for a project.
+
+    Returns the collection id on success, or None if the user has no
+    embedding configured (the project is still saved without a knowledge
+    base — collection can be created later).
+    """
+    if getattr(user, "embedding_id", None) is None:
+        return None
+    # Imported here to avoid a cycle (rag.api → projects → rag.api).
+    from giga_agent.modules.rag.api.collections import create_collection_for_user
+
+    try:
+        collection = await create_collection_for_user(
+            user=user,
+            db=db,
+            name=_project_collection_name(project_id),
+            metadata={"project_id": str(project_id)},
+        )
+    except Exception:
+        logger.exception("Failed to create project-backed RAG collection")
+        return None
+    return collection.id
 
 
 @router.get("/", response_model=list[ProjectResponse])
@@ -48,6 +86,13 @@ async def create_project(
         raise HTTPException(
             status_code=409, detail="Project with this name already exists"
         )
+
+    collection_id = await _try_create_project_collection(
+        user=current_user, db=db, project_id=project.id
+    )
+    if collection_id is not None:
+        project = await repo.update(project, collection_id=collection_id)
+
     return ProjectResponse.model_validate(project)
 
 
@@ -94,5 +139,18 @@ async def delete_project(
     project = await repo.get_for_owner(project_id, current_user.id)
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
+
+    collection_id = project.collection_id
     await repo.delete(project)
+    if collection_id is not None:
+        try:
+            collections = RagCollectionsRepository(db)
+            collection = await collections.get_by_id(
+                owner_id=current_user.id, collection_id=collection_id
+            )
+            if collection is not None:
+                await db.delete(collection)
+                await db.commit()
+        except Exception:
+            logger.exception("Failed to delete project-backed RAG collection")
     return None

--- a/backend/giga_agent/modules/projects/api.py
+++ b/backend/giga_agent/modules/projects/api.py
@@ -106,6 +106,16 @@ async def get_project(
     project = await repo.get_for_owner(project_id, current_user.id)
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
+
+    # Lazy-create a backing collection for legacy projects that were
+    # created before the user configured an embedding model.
+    if project.collection_id is None:
+        collection_id = await _try_create_project_collection(
+            user=current_user, db=db, project_id=project.id
+        )
+        if collection_id is not None:
+            project = await repo.update(project, collection_id=collection_id)
+
     return ProjectResponse.model_validate(project)
 
 

--- a/backend/giga_agent/modules/projects/module.py
+++ b/backend/giga_agent/modules/projects/module.py
@@ -16,25 +16,64 @@ from giga_agent.models.project import Project, ProjectRepository
 from giga_agent.models.users import UserShort
 from giga_agent.modules.projects.api import router as projects_router
 from giga_agent.modules.projects.prompts import PROJECT_INSTRUCTIONS_HEADER
+from giga_agent.utils.langgraph_sdk import get_client
 
 logger = get_logger(__name__)
 
 
-def _resolve_project_id(config: RunnableConfig | dict[str, Any] | None) -> uuid.UUID | None:
+def _coerce_uuid(raw: Any) -> uuid.UUID | None:
+    if raw is None:
+        return None
+    try:
+        return uuid.UUID(str(raw))
+    except (ValueError, TypeError):
+        return None
+
+
+def _project_id_from_dict(d: Mapping[str, Any] | None) -> uuid.UUID | None:
+    if not isinstance(d, Mapping):
+        return None
+    return _coerce_uuid(d.get("project_id"))
+
+
+def _thread_id_from_config(
+    config: RunnableConfig | dict[str, Any] | None,
+) -> str | None:
     if not isinstance(config, dict):
         return None
     for source in ("metadata", "configurable"):
         section = config.get(source) or {}
         if not isinstance(section, Mapping):
             continue
-        raw = section.get("project_id")
-        if raw is None:
-            continue
-        try:
-            return uuid.UUID(str(raw))
-        except (ValueError, TypeError):
-            return None
+        thread_id = section.get("thread_id")
+        if isinstance(thread_id, str) and thread_id.strip():
+            return thread_id.strip().strip("/")
     return None
+
+
+async def _resolve_project_id(
+    config: RunnableConfig | dict[str, Any] | None,
+) -> uuid.UUID | None:
+    if not isinstance(config, dict):
+        return None
+    for source in ("metadata", "configurable"):
+        section = config.get(source) or {}
+        candidate = _project_id_from_dict(section)
+        if candidate is not None:
+            return candidate
+
+    thread_id = _thread_id_from_config(config)
+    if not thread_id:
+        return None
+    try:
+        client = get_client(config)
+        thread = await client.threads.get(thread_id)
+    except Exception:
+        logger.exception(
+            "ProjectsModule: failed to fetch thread metadata for %s", thread_id
+        )
+        return None
+    return _project_id_from_dict(thread.get("metadata"))
 
 
 class ProjectsModule(BaseModule):
@@ -58,7 +97,7 @@ class ProjectsModule(BaseModule):
         if user is None or config is None:
             return None
 
-        project_id = _resolve_project_id(config)
+        project_id = await _resolve_project_id(config)
         if project_id is None:
             return None
 

--- a/backend/giga_agent/modules/projects/module.py
+++ b/backend/giga_agent/modules/projects/module.py
@@ -1,12 +1,40 @@
-"""ProjectsModule — exposes Projects CRUD API."""
+"""ProjectsModule — exposes Projects CRUD API and injects project instructions."""
 
 from __future__ import annotations
 
-from typing import Any
+import uuid
+from typing import Any, Mapping, Optional
 
+from langchain_core.runnables import RunnableConfig
+
+from giga_agent.core.agent.base import BaseAgent
+from giga_agent.core.agent.types import AgentState
+from giga_agent.core.db import get_session_factory
+from giga_agent.core.logging import get_logger
 from giga_agent.core.module import BaseModule
-from giga_agent.models.project import Project
+from giga_agent.models.project import Project, ProjectRepository
+from giga_agent.models.users import UserShort
 from giga_agent.modules.projects.api import router as projects_router
+from giga_agent.modules.projects.prompts import PROJECT_INSTRUCTIONS_HEADER
+
+logger = get_logger(__name__)
+
+
+def _resolve_project_id(config: RunnableConfig | dict[str, Any] | None) -> uuid.UUID | None:
+    if not isinstance(config, dict):
+        return None
+    for source in ("metadata", "configurable"):
+        section = config.get(source) or {}
+        if not isinstance(section, Mapping):
+            continue
+        raw = section.get("project_id")
+        if raw is None:
+            continue
+        try:
+            return uuid.UUID(str(raw))
+        except (ValueError, TypeError):
+            return None
+    return None
 
 
 class ProjectsModule(BaseModule):
@@ -17,3 +45,36 @@ class ProjectsModule(BaseModule):
 
     def get_models(self, **kwargs: Any) -> list[type]:
         return [Project]
+
+    async def get_instructions(
+        self,
+        user: UserShort | None,
+        agent: BaseAgent,
+        state: Optional[AgentState] = None,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> str | None:
+        _ = agent, state, kwargs
+        if user is None or config is None:
+            return None
+
+        project_id = _resolve_project_id(config)
+        if project_id is None:
+            return None
+
+        try:
+            factory = await get_session_factory()
+            async with factory() as session:
+                repo = ProjectRepository(session)
+                project = await repo.get_for_owner(project_id, user.id)
+        except Exception:
+            logger.exception("ProjectsModule.get_instructions: lookup failed")
+            return None
+
+        if project is None or not project.instructions:
+            return None
+
+        return PROJECT_INSTRUCTIONS_HEADER.format(
+            name=project.name,
+            instructions=project.instructions.strip(),
+        )

--- a/backend/giga_agent/modules/projects/module.py
+++ b/backend/giga_agent/modules/projects/module.py
@@ -48,8 +48,9 @@ class ProjectsModule(BaseModule):
         try:
             factory = await get_session_factory()
             async with factory() as session:
-                repo = ProjectRepository(session)
-                project = await repo.get_for_owner(project_id, user.id)
+                project = await ProjectRepository.get_cached_or_db_for_owner(
+                    project_id, user.id, session=session
+                )
         except Exception:
             logger.exception("ProjectsModule.get_instructions: lookup failed")
             return None

--- a/backend/giga_agent/modules/projects/module.py
+++ b/backend/giga_agent/modules/projects/module.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import uuid
-from typing import Any, Mapping, Optional
+from typing import Any, Optional
 
 from langchain_core.runnables import RunnableConfig
 
@@ -16,64 +15,9 @@ from giga_agent.models.project import Project, ProjectRepository
 from giga_agent.models.users import UserShort
 from giga_agent.modules.projects.api import router as projects_router
 from giga_agent.modules.projects.prompts import PROJECT_INSTRUCTIONS_HEADER
-from giga_agent.utils.langgraph_sdk import get_client
+from giga_agent.modules.projects.utils import resolve_project_id
 
 logger = get_logger(__name__)
-
-
-def _coerce_uuid(raw: Any) -> uuid.UUID | None:
-    if raw is None:
-        return None
-    try:
-        return uuid.UUID(str(raw))
-    except (ValueError, TypeError):
-        return None
-
-
-def _project_id_from_dict(d: Mapping[str, Any] | None) -> uuid.UUID | None:
-    if not isinstance(d, Mapping):
-        return None
-    return _coerce_uuid(d.get("project_id"))
-
-
-def _thread_id_from_config(
-    config: RunnableConfig | dict[str, Any] | None,
-) -> str | None:
-    if not isinstance(config, dict):
-        return None
-    for source in ("metadata", "configurable"):
-        section = config.get(source) or {}
-        if not isinstance(section, Mapping):
-            continue
-        thread_id = section.get("thread_id")
-        if isinstance(thread_id, str) and thread_id.strip():
-            return thread_id.strip().strip("/")
-    return None
-
-
-async def _resolve_project_id(
-    config: RunnableConfig | dict[str, Any] | None,
-) -> uuid.UUID | None:
-    if not isinstance(config, dict):
-        return None
-    for source in ("metadata", "configurable"):
-        section = config.get(source) or {}
-        candidate = _project_id_from_dict(section)
-        if candidate is not None:
-            return candidate
-
-    thread_id = _thread_id_from_config(config)
-    if not thread_id:
-        return None
-    try:
-        client = get_client(config)
-        thread = await client.threads.get(thread_id)
-    except Exception:
-        logger.exception(
-            "ProjectsModule: failed to fetch thread metadata for %s", thread_id
-        )
-        return None
-    return _project_id_from_dict(thread.get("metadata"))
 
 
 class ProjectsModule(BaseModule):
@@ -97,7 +41,7 @@ class ProjectsModule(BaseModule):
         if user is None or config is None:
             return None
 
-        project_id = await _resolve_project_id(config)
+        project_id = await resolve_project_id(config)
         if project_id is None:
             return None
 

--- a/backend/giga_agent/modules/projects/module.py
+++ b/backend/giga_agent/modules/projects/module.py
@@ -1,0 +1,19 @@
+"""ProjectsModule — exposes Projects CRUD API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from giga_agent.core.module import BaseModule
+from giga_agent.models.project import Project
+from giga_agent.modules.projects.api import router as projects_router
+
+
+class ProjectsModule(BaseModule):
+    id: str = "projects"
+
+    def get_api_router(self, **kwargs: Any):
+        return projects_router
+
+    def get_models(self, **kwargs: Any) -> list[type]:
+        return [Project]

--- a/backend/giga_agent/modules/projects/prompts.py
+++ b/backend/giga_agent/modules/projects/prompts.py
@@ -1,0 +1,8 @@
+PROJECT_INSTRUCTIONS_HEADER = (
+    "# Project context\n"
+    "This conversation belongs to project **{name}**. "
+    "Follow the project-specific instructions below as additional guidance "
+    "on top of your general system prompt.\n\n"
+    "## Project instructions\n"
+    "{instructions}"
+)

--- a/backend/giga_agent/modules/projects/utils.py
+++ b/backend/giga_agent/modules/projects/utils.py
@@ -1,0 +1,75 @@
+"""Shared helpers for resolving project context from a runtime config."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Mapping
+
+from langchain_core.runnables import RunnableConfig
+
+from giga_agent.core.logging import get_logger
+from giga_agent.utils.langgraph_sdk import get_client
+
+logger = get_logger(__name__)
+
+
+def _coerce_uuid(raw: Any) -> uuid.UUID | None:
+    if raw is None:
+        return None
+    try:
+        return uuid.UUID(str(raw))
+    except (ValueError, TypeError):
+        return None
+
+
+def _project_id_from_dict(d: Mapping[str, Any] | None) -> uuid.UUID | None:
+    if not isinstance(d, Mapping):
+        return None
+    return _coerce_uuid(d.get("project_id"))
+
+
+def _thread_id_from_config(
+    config: RunnableConfig | dict[str, Any] | None,
+) -> str | None:
+    if not isinstance(config, dict):
+        return None
+    for source in ("metadata", "configurable"):
+        section = config.get(source) or {}
+        if not isinstance(section, Mapping):
+            continue
+        thread_id = section.get("thread_id")
+        if isinstance(thread_id, str) and thread_id.strip():
+            return thread_id.strip().strip("/")
+    return None
+
+
+async def resolve_project_id(
+    config: RunnableConfig | dict[str, Any] | None,
+) -> uuid.UUID | None:
+    """Resolve the project_id for the current run.
+
+    Looks at config.metadata / config.configurable first, then falls back
+    to fetching thread metadata via the LangGraph SDK (because thread
+    metadata is not merged into the runtime config by default).
+    """
+    if not isinstance(config, dict):
+        return None
+    for source in ("metadata", "configurable"):
+        section = config.get(source) or {}
+        candidate = _project_id_from_dict(section)
+        if candidate is not None:
+            return candidate
+
+    thread_id = _thread_id_from_config(config)
+    if not thread_id:
+        return None
+    try:
+        client = get_client(config)
+        thread = await client.threads.get(thread_id)
+    except Exception:
+        logger.exception(
+            "resolve_project_id: failed to fetch thread metadata for %s",
+            thread_id,
+        )
+        return None
+    return _project_id_from_dict(thread.get("metadata"))

--- a/backend/giga_agent/modules/rag/api/collections.py
+++ b/backend/giga_agent/modules/rag/api/collections.py
@@ -106,6 +106,65 @@ def _qdrant_delete_helpers():
     return build_filter, delete_by_filter, get_qdrant_client, resolve_qdrant_collection
 
 
+async def delete_collection(
+    *,
+    db: AsyncSession,
+    collection,
+) -> None:
+    """Fully delete a RAG collection and all of its backing data.
+
+    Removes the collection's files from sandbox storage (best-effort),
+    purges its chunks from the vector DB, and deletes the collection row.
+
+    Access control is the caller's responsibility — ``collection`` must be an
+    already-resolved row the caller is allowed to delete.
+    """
+    repo = RagCollectionsRepository(db)
+
+    # Best-effort delete all files from sandbox storage (S3) + remove core_files metadata.
+    docs_repo = RagDocumentsRepository(db)
+    offset = 0
+    limit = 200
+    while True:
+        docs = await docs_repo.list_by_collection(
+            owner_id=collection.owner_id,
+            collection_id=collection.id,
+            limit=limit,
+            offset=offset,
+        )
+        if not docs:
+            break
+        for d in docs:
+            if not d.sandbox_path:
+                continue
+            await SandboxManager(db).delete_file_by_path_for_user(
+                user_id=collection.owner_id,
+                sandbox_path=d.sandbox_path,
+            )
+        offset += len(docs)
+
+    # Remove all chunks belonging to this collection from the vector DB.
+    build_filter, delete_by_filter, get_qdrant_client, resolve_qdrant_collection = (
+        _qdrant_delete_helpers()
+    )
+    qdrant_client = get_qdrant_client()
+    runtime = await EmbeddingManager.resolve_by_id(collection.embedding_id, session=db)
+    vector_size = int(runtime.vector_size)
+    qdrant_collection = await resolve_qdrant_collection(
+        client=qdrant_client,
+        collection_name=rag_qdrant_collection_name_for_embedding(collection.embedding_id),
+        vector_size=vector_size,
+    )
+    qfilter = build_filter(owner_id=collection.owner_id, collection_id=collection.id)
+    await delete_by_filter(
+        client=qdrant_client,
+        collection_name=qdrant_collection,
+        query_filter=qfilter,
+    )
+
+    await repo.delete(owner_id=collection.owner_id, collection_id=collection.id)
+
+
 @router.post(
     "",
     response_model=CollectionResponse,
@@ -210,48 +269,7 @@ async def collections_delete(
             detail="Access denied",
         )
 
-    # Best-effort delete all files from sandbox storage (S3) + remove core_files metadata.
-    docs_repo = RagDocumentsRepository(db)
-    offset = 0
-    limit = 200
-    while True:
-        docs = await docs_repo.list_by_collection(
-            owner_id=collection.owner_id,
-            collection_id=collection_id,
-            limit=limit,
-            offset=offset,
-        )
-        if not docs:
-            break
-        for d in docs:
-            if not d.sandbox_path:
-                continue
-            await SandboxManager(db).delete_file_by_path_for_user(
-                user_id=collection.owner_id,
-                sandbox_path=d.sandbox_path,
-            )
-        offset += len(docs)
-
-    # Remove all chunks belonging to this collection from the vector DB.
-    build_filter, delete_by_filter, get_qdrant_client, resolve_qdrant_collection = (
-        _qdrant_delete_helpers()
-    )
-    qdrant_client = get_qdrant_client()
-    runtime = await EmbeddingManager.resolve_by_id(collection.embedding_id, session=db)
-    vector_size = int(runtime.vector_size)
-    qdrant_collection = await resolve_qdrant_collection(
-        client=qdrant_client,
-        collection_name=rag_qdrant_collection_name_for_embedding(collection.embedding_id),
-        vector_size=vector_size,
-    )
-    qfilter = build_filter(owner_id=collection.owner_id, collection_id=collection_id)
-    await delete_by_filter(
-        client=qdrant_client,
-        collection_name=qdrant_collection,
-        query_filter=qfilter,
-    )
-
-    await repo.delete(owner_id=collection.owner_id, collection_id=collection_id)
+    await delete_collection(db=db, collection=collection)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/giga_agent/modules/rag/api/collections.py
+++ b/backend/giga_agent/modules/rag/api/collections.py
@@ -58,6 +58,50 @@ def _qdrant_create_helpers():
     return get_qdrant_client, resolve_qdrant_collection
 
 
+async def create_collection_for_user(
+    *,
+    user: UserShort,
+    db: AsyncSession,
+    name: str,
+    metadata: dict | None = None,
+):
+    """Create a RAG collection on behalf of a user.
+
+    Raises HTTPException(400) if the user has no embedding configured, or
+    HTTPException(409) on a duplicate name. Ensures the underlying Qdrant
+    tech collection exists for the user's embedding model.
+    """
+    if user.embedding_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User embedding model is not configured",
+        )
+
+    runtime = await EmbeddingManager.resolve_by_id(user.embedding_id, session=db)
+    vector_size = int(runtime.vector_size)
+
+    client = get_qdrant_client()
+    await resolve_qdrant_collection(
+        client=client,
+        collection_name=rag_qdrant_collection_name_for_embedding(user.embedding_id),
+        vector_size=vector_size,
+    )
+
+    repo = RagCollectionsRepository(db)
+    try:
+        return await repo.create(
+            owner_id=user.id,
+            name=name,
+            embedding_id=user.embedding_id,
+            metadata=metadata,
+        )
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Collection with this name already exists",
+        )
+
+
 def _qdrant_delete_helpers():
     return build_filter, delete_by_filter, get_qdrant_client, resolve_qdrant_collection
 
@@ -73,41 +117,12 @@ async def collections_create(
     db: Annotated[AsyncSession, Depends(get_session)],
 ):
     """Creates a new collection with optional metadata."""
-    if current_user.embedding_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="User embedding model is not configured",
-        )
-
-    # Ensure Qdrant tech collection exists for this embedding model.
-    runtime = await EmbeddingManager.resolve_by_id(
-        current_user.embedding_id,
-        session=db,
+    created = await create_collection_for_user(
+        user=current_user,
+        db=db,
+        name=collection_data.name,
+        metadata=collection_data.metadata,
     )
-    vector_size = int(runtime.vector_size)
-
-    get_qdrant_client, resolve_qdrant_collection = _qdrant_create_helpers()
-    client = get_qdrant_client()
-    await resolve_qdrant_collection(
-        client=client,
-        collection_name=rag_qdrant_collection_name_for_embedding(current_user.embedding_id),
-        vector_size=vector_size,
-    )
-
-    repo = RagCollectionsRepository(db)
-    try:
-        created = await repo.create(
-            owner_id=current_user.id,
-            name=collection_data.name,
-            embedding_id=current_user.embedding_id,
-            metadata=collection_data.metadata,
-        )
-    except IntegrityError:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Collection with this name already exists",
-        )
-
     return CollectionResponse(
         uuid=str(created.id),
         name=created.name,
@@ -121,7 +136,11 @@ async def collections_list(
     current_user: Annotated[UserShort, Depends(get_current_active_user)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ):
-    """Lists all available collections (name and UUID)."""
+    """Lists all available collections (name and UUID).
+
+    Collections owned by a Project are hidden — they're managed on the
+    project's own page, not in the global RAG list.
+    """
     repo = RagCollectionsRepository(db)
     rows = await repo.list_readable_with_edit_for_user(user_id=current_user.id)
     return [
@@ -132,6 +151,7 @@ async def collections_list(
             metadata=collection.metadata_ or {},
         )
         for collection, can_edit in rows
+        if not (collection.metadata_ or {}).get("project_id")
     ]
 
 

--- a/backend/giga_agent/modules/rag/module.py
+++ b/backend/giga_agent/modules/rag/module.py
@@ -11,8 +11,10 @@ from giga_agent.core.agent.types import AgentState
 from giga_agent.core.agent.types import Collection as StateCollection
 from giga_agent.core.db import get_session_factory
 from giga_agent.core.module import BaseModule
+from giga_agent.models.project import ProjectRepository
 from giga_agent.models.rag import RagCollectionsRepository
 from giga_agent.models.users import UserShort
+from giga_agent.modules.projects.utils import resolve_project_id
 from giga_agent.modules.rag.api import router as rag_api_router
 from giga_agent.modules.rag.tools import get_documents, get_rag_info
 
@@ -62,23 +64,73 @@ class RagModule(BaseModule):
         config=None,
         **kwargs: Any,
     ) -> str | None:
-        _ = agent, state, kwargs
+        _ = agent, kwargs
         if _is_cli():
             return None
         if user is None:
             return None
         if state is not None:
-            return get_rag_info(state.get("collections", []))
+            collections = list(state.get("collections", []))
+        else:
+            factory = await get_session_factory()
+            async with factory() as session:
+                rows = await RagCollectionsRepository(session).list_by_owner(
+                    user.id
+                )
+            collections = [
+                {
+                    "uuid": str(r.id),
+                    "name": r.name,
+                    "metadata": (r.metadata_ or {}),  # type: ignore[typeddict-item]
+                }
+                for r in rows
+            ]
+
+        await self._merge_project_collection(collections, user, config)
+        return get_rag_info(collections)
+
+    @staticmethod
+    async def _merge_project_collection(
+        collections: list[StateCollection],
+        user: UserShort,
+        config: Any,
+    ) -> None:
+        """Surface a project's backing RAG collection to the agent.
+
+        Project collections are filtered out of the user's "active
+        collections" toggle in chat UI, so they never reach state on
+        their own. When the current chat belongs to a project, append
+        the project's collection to the list shown to the agent.
+        """
+        if config is None:
+            return
+        try:
+            project_id = await resolve_project_id(config)
+        except Exception:
+            return
+        if project_id is None:
+            return
+
+        existing_uuids = {c.get("uuid") for c in collections}
         factory = await get_session_factory()
         async with factory() as session:
-            rows = await RagCollectionsRepository(session).list_by_owner(user.id)
-
-        collections: list[StateCollection] = [
-            {
-                "uuid": str(r.id),
-                "name": r.name,
-                "metadata": (r.metadata_ or {}),  # type: ignore[typeddict-item]
-            }
-            for r in rows
-        ]
-        return get_rag_info(collections)
+            project = await ProjectRepository(session).get_for_owner(
+                project_id, user.id
+            )
+            if project is None or project.collection_id is None:
+                return
+            collection_uuid = str(project.collection_id)
+            if collection_uuid in existing_uuids:
+                return
+            row = await RagCollectionsRepository(session).get_by_id(
+                owner_id=user.id, collection_id=project.collection_id
+            )
+            if row is None:
+                return
+            collections.append(
+                {
+                    "uuid": collection_uuid,
+                    "name": row.name,
+                    "metadata": (row.metadata_ or {}),  # type: ignore[typeddict-item]
+                }
+            )

--- a/backend/tests/modules/test_projects_api.py
+++ b/backend/tests/modules/test_projects_api.py
@@ -1,0 +1,117 @@
+import types
+import unittest
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from giga_agent.core.db import Base, get_session
+from giga_agent.modules.auth.api import get_current_active_user
+from giga_agent.modules.projects.api import router
+
+
+class ProjectsAPITests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        self.app = FastAPI()
+        self.app.include_router(router, prefix="/projects")
+
+        self.user = types.SimpleNamespace(id=uuid.uuid4(), is_active=True)
+
+        async def _override_current_user():
+            return self.user
+
+        async def _override_get_session():
+            async with self.session_factory() as session:
+                yield session
+
+        self.app.dependency_overrides[get_current_active_user] = _override_current_user
+        self.app.dependency_overrides[get_session] = _override_get_session
+        self.client = TestClient(self.app)
+
+    async def asyncTearDown(self) -> None:
+        await self.engine.dispose()
+
+    def _switch_user(self) -> None:
+        new_user = types.SimpleNamespace(id=uuid.uuid4(), is_active=True)
+
+        async def _override_current_user():
+            return new_user
+
+        self.app.dependency_overrides[get_current_active_user] = _override_current_user
+        self.user = new_user
+
+    def test_list_empty(self):
+        resp = self.client.get("/projects/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), [])
+
+    def test_create_and_get(self):
+        resp = self.client.post(
+            "/projects/",
+            json={
+                "name": "alpha",
+                "description": "first project",
+                "instructions": "be concise",
+            },
+        )
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["name"], "alpha")
+        self.assertEqual(data["description"], "first project")
+        self.assertEqual(data["instructions"], "be concise")
+        self.assertEqual(data["owner_id"], str(self.user.id))
+        project_id = data["id"]
+
+        resp = self.client.get(f"/projects/{project_id}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["id"], project_id)
+
+    def test_create_duplicate_name_returns_409(self):
+        self.client.post("/projects/", json={"name": "dup"})
+        resp = self.client.post("/projects/", json={"name": "dup"})
+        self.assertEqual(resp.status_code, 409)
+
+    def test_update_changes_fields(self):
+        created = self.client.post(
+            "/projects/", json={"name": "p1", "instructions": "old"}
+        ).json()
+        resp = self.client.patch(
+            f"/projects/{created['id']}",
+            json={"instructions": "new", "description": "desc"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["instructions"], "new")
+        self.assertEqual(data["description"], "desc")
+        self.assertEqual(data["name"], "p1")
+
+    def test_delete_removes_project(self):
+        created = self.client.post("/projects/", json={"name": "del"}).json()
+        resp = self.client.delete(f"/projects/{created['id']}")
+        self.assertEqual(resp.status_code, 204)
+        resp = self.client.get(f"/projects/{created['id']}")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_owner_isolation(self):
+        owner_a = self.client.post("/projects/", json={"name": "a-proj"}).json()
+        self._switch_user()
+        resp = self.client.get("/projects/")
+        self.assertEqual(resp.json(), [])
+        resp = self.client.get(f"/projects/{owner_a['id']}")
+        self.assertEqual(resp.status_code, 404)
+        resp = self.client.patch(
+            f"/projects/{owner_a['id']}", json={"name": "hijacked"}
+        )
+        self.assertEqual(resp.status_code, 404)
+        resp = self.client.delete(f"/projects/{owner_a['id']}")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_get_unknown_returns_404(self):
+        resp = self.client.get(f"/projects/{uuid.uuid4()}")
+        self.assertEqual(resp.status_code, 404)

--- a/backend/tests/modules/test_projects_api.py
+++ b/backend/tests/modules/test_projects_api.py
@@ -1,12 +1,14 @@
 import types
 import unittest
 import uuid
+from unittest.mock import patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from giga_agent.core.db import Base, get_session
+from giga_agent.models.rag import RagCollection, RagCollectionsRepository
 from giga_agent.modules.auth.api import get_current_active_user
 from giga_agent.modules.projects.api import router
 
@@ -115,3 +117,92 @@ class ProjectsAPITests(unittest.IsolatedAsyncioTestCase):
     def test_get_unknown_returns_404(self):
         resp = self.client.get(f"/projects/{uuid.uuid4()}")
         self.assertEqual(resp.status_code, 404)
+
+
+class ProjectsAPIWithCollectionTests(unittest.IsolatedAsyncioTestCase):
+    """Verifies project create/delete also handles a backing RAG collection."""
+
+    async def asyncSetUp(self) -> None:
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        self.app = FastAPI()
+        self.app.include_router(router, prefix="/projects")
+
+        self.embedding_id = uuid.uuid4()
+        self.user = types.SimpleNamespace(
+            id=uuid.uuid4(), is_active=True, embedding_id=self.embedding_id
+        )
+
+        async def _override_current_user():
+            return self.user
+
+        async def _override_get_session():
+            async with self.session_factory() as session:
+                yield session
+
+        self.app.dependency_overrides[get_current_active_user] = _override_current_user
+        self.app.dependency_overrides[get_session] = _override_get_session
+        self.client = TestClient(self.app)
+
+        async def fake_create(*, user, db, name, metadata=None):
+            repo = RagCollectionsRepository(db)
+            return await repo.create(
+                owner_id=user.id,
+                name=name,
+                embedding_id=user.embedding_id,
+                metadata=metadata,
+            )
+
+        self._patcher = patch(
+            "giga_agent.modules.rag.api.collections.create_collection_for_user",
+            new=fake_create,
+        )
+        self._patcher.start()
+
+    async def asyncTearDown(self) -> None:
+        self._patcher.stop()
+        await self.engine.dispose()
+
+    async def _count_collections(self) -> int:
+        from sqlalchemy import select
+
+        async with self.session_factory() as session:
+            result = await session.execute(select(RagCollection))
+            return len(list(result.scalars().all()))
+
+    async def test_create_project_creates_backing_collection(self):
+        resp = self.client.post("/projects/", json={"name": "with-kb"})
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertIsNotNone(data["collection_id"])
+
+        async with self.session_factory() as session:
+            from sqlalchemy import select
+
+            result = await session.execute(select(RagCollection))
+            collections = list(result.scalars().all())
+            self.assertEqual(len(collections), 1)
+            self.assertEqual(
+                collections[0].metadata_.get("project_id"), data["id"]
+            )
+            self.assertEqual(str(collections[0].id), data["collection_id"])
+
+    async def test_delete_project_cascades_collection(self):
+        created = self.client.post(
+            "/projects/", json={"name": "del-with-kb"}
+        ).json()
+        self.assertEqual(await self._count_collections(), 1)
+
+        resp = self.client.delete(f"/projects/{created['id']}")
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(await self._count_collections(), 0)
+
+    async def test_user_without_embedding_creates_project_without_collection(self):
+        self.user.embedding_id = None
+        resp = self.client.post("/projects/", json={"name": "no-kb"})
+        self.assertEqual(resp.status_code, 201)
+        self.assertIsNone(resp.json()["collection_id"])
+        self.assertEqual(await self._count_collections(), 0)

--- a/backend/tests/modules/test_projects_api.py
+++ b/backend/tests/modules/test_projects_api.py
@@ -206,3 +206,23 @@ class ProjectsAPIWithCollectionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.status_code, 201)
         self.assertIsNone(resp.json()["collection_id"])
         self.assertEqual(await self._count_collections(), 0)
+
+    async def test_get_lazily_creates_collection_for_legacy_project(self):
+        # Project created when embedding was missing → no backing collection.
+        self.user.embedding_id = None
+        created = self.client.post("/projects/", json={"name": "legacy"}).json()
+        self.assertIsNone(created["collection_id"])
+        self.assertEqual(await self._count_collections(), 0)
+
+        # User configures embedding later; opening the project should now
+        # bring a collection into existence.
+        self.user.embedding_id = self.embedding_id
+        resp = self.client.get(f"/projects/{created['id']}")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIsNotNone(data["collection_id"])
+        self.assertEqual(await self._count_collections(), 1)
+
+        # Idempotent — second GET doesn't create a duplicate.
+        self.client.get(f"/projects/{created['id']}")
+        self.assertEqual(await self._count_collections(), 1)

--- a/backend/tests/modules/test_projects_module.py
+++ b/backend/tests/modules/test_projects_module.py
@@ -99,3 +99,92 @@ class ProjectsModuleInstructionsTests(unittest.IsolatedAsyncioTestCase):
             {"metadata": {"project_id": str(empty_project.id)}}
         )
         self.assertIsNone(result)
+
+
+class RagModuleProjectCollectionMergeTests(unittest.IsolatedAsyncioTestCase):
+    """RagModule must surface a project's backing collection so the agent
+    can search it even though it's hidden from the user's global RAG list."""
+
+    async def asyncSetUp(self) -> None:
+        from giga_agent.models.rag import RagCollection, RagCollectionsRepository
+        from giga_agent.modules.rag.module import RagModule
+
+        self.RagModule = RagModule
+        self.RagCollection = RagCollection
+        self.RagCollectionsRepository = RagCollectionsRepository
+
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        self.owner_id = uuid.uuid4()
+        self.embedding_id = uuid.uuid4()
+        async with self.session_factory() as session:
+            project_repo = ProjectRepository(session)
+            self.project = await project_repo.create(
+                owner_id=self.owner_id, name="kb-project"
+            )
+            self.collection = await RagCollectionsRepository(session).create(
+                owner_id=self.owner_id,
+                name=f"__project_{self.project.id}__",
+                embedding_id=self.embedding_id,
+                metadata={"project_id": str(self.project.id)},
+            )
+            self.project = await project_repo.update(
+                self.project, collection_id=self.collection.id
+            )
+
+        self.user = types.SimpleNamespace(
+            id=self.owner_id, embedding_id=self.embedding_id
+        )
+        self.module = self.RagModule()
+
+        self._patcher = patch(
+            "giga_agent.modules.rag.module.get_session_factory",
+            new=self._fake_get_session_factory,
+        )
+        self._patcher.start()
+
+    async def asyncTearDown(self) -> None:
+        self._patcher.stop()
+        await self.engine.dispose()
+
+    async def _fake_get_session_factory(self):
+        return self.session_factory
+
+    async def test_project_collection_appears_for_project_chat(self):
+        state = {"collections": []}
+        config = {"metadata": {"project_id": str(self.project.id)}}
+        result = await self.module.get_instructions(
+            user=self.user, agent=None, state=state, config=config
+        )
+        self.assertIsNotNone(result)
+        self.assertIn(str(self.collection.id), result)
+        self.assertIn(self.collection.name, result)
+
+    async def test_no_merge_when_chat_has_no_project(self):
+        state = {"collections": []}
+        config = {"metadata": {}}
+        result = await self.module.get_instructions(
+            user=self.user, agent=None, state=state, config=config
+        )
+        # collections list stays empty → the "ДОСТУПНЫХ КОЛЛЕКЦИЙ НЕТ" branch
+        self.assertIsNotNone(result)
+        self.assertNotIn(str(self.collection.id), result)
+
+    async def test_does_not_duplicate_if_already_active(self):
+        state = {
+            "collections": [
+                {
+                    "uuid": str(self.collection.id),
+                    "name": self.collection.name,
+                    "metadata": {"project_id": str(self.project.id)},
+                }
+            ]
+        }
+        config = {"metadata": {"project_id": str(self.project.id)}}
+        result = await self.module.get_instructions(
+            user=self.user, agent=None, state=state, config=config
+        )
+        self.assertEqual(result.count(str(self.collection.id)), 1)

--- a/backend/tests/modules/test_projects_module.py
+++ b/backend/tests/modules/test_projects_module.py
@@ -1,0 +1,101 @@
+import types
+import unittest
+import uuid
+from unittest.mock import patch
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from giga_agent.core.db import Base
+from giga_agent.models.project import ProjectRepository
+from giga_agent.modules.projects.module import ProjectsModule
+
+
+class ProjectsModuleInstructionsTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        self.owner_id = uuid.uuid4()
+        async with self.session_factory() as session:
+            repo = ProjectRepository(session)
+            self.project = await repo.create(
+                owner_id=self.owner_id,
+                name="alpha",
+                instructions="Always answer in Russian.",
+            )
+
+        self.user = types.SimpleNamespace(id=self.owner_id)
+        self.module = ProjectsModule()
+
+        self._patcher = patch(
+            "giga_agent.modules.projects.module.get_session_factory",
+            new=self._fake_get_session_factory,
+        )
+        self._patcher.start()
+
+    async def asyncTearDown(self) -> None:
+        self._patcher.stop()
+        await self.engine.dispose()
+
+    async def _fake_get_session_factory(self):
+        return self.session_factory
+
+    async def _call(self, config):
+        return await self.module.get_instructions(
+            user=self.user, agent=None, state=None, config=config
+        )
+
+    async def test_returns_none_when_no_project_in_config(self):
+        result = await self._call({"metadata": {}, "configurable": {}})
+        self.assertIsNone(result)
+
+    async def test_returns_instructions_when_project_in_metadata(self):
+        result = await self._call(
+            {"metadata": {"project_id": str(self.project.id)}}
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("alpha", result)
+        self.assertIn("Always answer in Russian.", result)
+
+    async def test_returns_instructions_when_project_in_configurable(self):
+        result = await self._call(
+            {"configurable": {"project_id": str(self.project.id)}}
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("Always answer in Russian.", result)
+
+    async def test_returns_none_for_other_owner(self):
+        other_user = types.SimpleNamespace(id=uuid.uuid4())
+        result = await self.module.get_instructions(
+            user=other_user,
+            agent=None,
+            state=None,
+            config={"metadata": {"project_id": str(self.project.id)}},
+        )
+        self.assertIsNone(result)
+
+    async def test_returns_none_for_invalid_project_id(self):
+        result = await self._call({"metadata": {"project_id": "not-a-uuid"}})
+        self.assertIsNone(result)
+
+    async def test_returns_none_when_user_missing(self):
+        result = await self.module.get_instructions(
+            user=None,
+            agent=None,
+            state=None,
+            config={"metadata": {"project_id": str(self.project.id)}},
+        )
+        self.assertIsNone(result)
+
+    async def test_returns_none_when_project_has_no_instructions(self):
+        async with self.session_factory() as session:
+            repo = ProjectRepository(session)
+            empty_project = await repo.create(
+                owner_id=self.owner_id, name="empty"
+            )
+        result = await self._call(
+            {"metadata": {"project_id": str(empty_project.id)}}
+        )
+        self.assertIsNone(result)

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -24,6 +24,7 @@ import { ThemeProvider } from "@/components/providers/theme.tsx";
 import { ConfirmProvider } from "@/components/providers/confirm.tsx";
 import { Toaster } from "@/components/ui/sonner.tsx";
 import MemoriesPage from "@/components/memories/MemoriesPage.tsx";
+import ProjectPage from "@/components/projects/ProjectPage.tsx";
 import LoginPage from "@/components/auth/LoginPage.tsx";
 import ProtectedRoute from "@/components/auth/ProtectedRoute.tsx";
 import SettingsPage from "@/components/settings-page";
@@ -149,6 +150,7 @@ const AppRoutes: React.FC<{
         <Route path="/oauth/callback" element={<OAuthCallback />} />
         <Route path="/rag" element={<RAGInterface />} />
         <Route path="/memories" element={<MemoriesPage />} />
+        <Route path="/projects/:projectId" element={<ProjectPage />} />
         <Route path="/demo/settings" element={<DemoSettings />} />
         <Route
           path="/settings"

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -11,6 +11,7 @@ import {
   Check,
   Cog,
   Files,
+  FolderOpen,
   Loader2,
   Mic,
   Paperclip,
@@ -50,6 +51,7 @@ import { useSkills } from "@/components/providers/skills.tsx";
 import { Switch } from "@/components/ui/switch";
 import { useNavigate, useParams } from "react-router-dom";
 import { useThreadAutoApprove } from "@/hooks/useThreadAutoApprove";
+import { useThreadProject } from "@/components/projects/useThreadProject";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -134,6 +136,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
   const navigate = useNavigate();
   const { threadId } = useParams<{ threadId?: string }>();
   const { autoApprove, setAutoApprove } = useThreadAutoApprove(threadId);
+  const { project: threadProject } = useThreadProject(threadId);
   const [message, setMessage] = useState("");
   const [isMobileDevice, setIsMobileDevice] = useState(
     getInitialIsMobileDevice,
@@ -842,6 +845,17 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
         </div>
       )}
       <div className="relative p-4 pb-3 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight max-w-[880px] mx-auto overflow-hidden">
+        {threadProject && (
+          <button
+            type="button"
+            onClick={() => navigate(`/projects/${threadProject.id}`)}
+            className="mb-2 inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            title="Открыть проект"
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+            <span className="truncate max-w-[200px]">{threadProject.name}</span>
+          </button>
+        )}
         <div className="relative">
           <input
             className="hidden"

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -845,17 +845,6 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
         </div>
       )}
       <div className="relative p-4 pb-3 bg-card dark:bg-input border-border rounded-lg print:hidden border-1 border-highlight max-w-[880px] mx-auto overflow-hidden">
-        {threadProject && (
-          <button
-            type="button"
-            onClick={() => navigate(`/projects/${threadProject.id}`)}
-            className="mb-2 inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-            title="Открыть проект"
-          >
-            <FolderOpen className="h-3.5 w-3.5" />
-            <span className="truncate max-w-[200px]">{threadProject.name}</span>
-          </button>
-        )}
         <div className="relative">
           <input
             className="hidden"
@@ -883,7 +872,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
               className="w-full min-h-[60px] max-h-[200px] resize-none font-sans p-2 rounded-md text-foreground placeholder:text-muted-foreground overflow-y-auto outline-none border-0 disabled:opacity-60 max-[900px]:min-h-[60px] max-[900px]:h-[60px]"
             />
             <div className={"flex"}>
-              <div className="flex items-center gap-1 flex-1">
+              <div className="flex items-center gap-1 flex-1 min-w-0">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
@@ -1069,6 +1058,17 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
                     </DropdownMenuSub>
                   </DropdownMenuContent>
                 </DropdownMenu>
+                {threadProject && (
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/projects/${threadProject.id}`)}
+                    className="inline-flex items-center gap-1 h-7 px-2 rounded-full text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors min-w-0 max-w-[180px]"
+                    title="Открыть проект"
+                  >
+                    <FolderOpen className="h-3.5 w-3.5 shrink-0" />
+                    <span className="truncate">{threadProject.name}</span>
+                  </button>
+                )}
                 {enabledCollectionCount > 0 && (
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/front/src/components/Sidebar.tsx
+++ b/front/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
   Brain,
+  ChevronDown,
   ChevronRight,
   Download,
   Files,
@@ -9,6 +10,7 @@ import {
   FolderPlus,
   Loader2,
   LogOut,
+  MessageSquarePlus,
   MoreHorizontal,
   Pencil,
   Settings as SettingsIcon,
@@ -142,6 +144,20 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
   const [createProjectError, setCreateProjectError] = useState<string | null>(
     null,
   );
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => {
+    try {
+      const raw = localStorage.getItem("sidebar_expanded_projects_v1");
+      return raw ? new Set(JSON.parse(raw)) : new Set();
+    } catch {
+      return new Set();
+    }
+  });
+  const [projectThreads, setProjectThreads] = useState<
+    Record<string, Thread[]>
+  >({});
+  const [projectThreadsLoading, setProjectThreadsLoading] = useState<
+    Record<string, boolean>
+  >({});
 
   const activeProjectId = useMemo(() => {
     const match = location.pathname.match(/^\/projects\/([^/?#]+)/);
@@ -593,6 +609,103 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
     navigate(`/projects/${projectId}`);
   };
 
+  const loadProjectThreads = React.useCallback(
+    async (projectId: string) => {
+      if (!langGraphClient) return;
+      setProjectThreadsLoading((prev) => ({ ...prev, [projectId]: true }));
+      try {
+        const list = await langGraphClient.threads.search({
+          metadata: { project_id: projectId },
+          limit: 50,
+          sortBy: "updated_at",
+          sortOrder: "desc",
+        });
+        setProjectThreads((prev) => ({ ...prev, [projectId]: list }));
+      } catch (e) {
+        console.error("Failed to load threads for project", projectId, e);
+      } finally {
+        setProjectThreadsLoading((prev) => ({ ...prev, [projectId]: false }));
+      }
+    },
+    [langGraphClient],
+  );
+
+  const toggleProjectExpanded = (projectId: string) => {
+    setExpandedProjects((prev) => {
+      const next = new Set(prev);
+      const wasOpen = next.has(projectId);
+      if (wasOpen) next.delete(projectId);
+      else next.add(projectId);
+      try {
+        localStorage.setItem(
+          "sidebar_expanded_projects_v1",
+          JSON.stringify(Array.from(next)),
+        );
+      } catch {
+        /* ignore */
+      }
+      if (!wasOpen && projectThreads[projectId] === undefined) {
+        void loadProjectThreads(projectId);
+      }
+      return next;
+    });
+  };
+
+  // Auto-load threads for any project that's already expanded but has no
+  // data yet (e.g., on first paint when expansion came from localStorage).
+  useEffect(() => {
+    if (!langGraphClient) return;
+    for (const projectId of expandedProjects) {
+      if (projectThreads[projectId] === undefined) {
+        void loadProjectThreads(projectId);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandedProjects, langGraphClient, loadProjectThreads]);
+
+  // Refresh open project threads when something elsewhere (e.g., new chat
+  // from a project page, project deletion) signals a refresh.
+  useEffect(() => {
+    const handler = () => {
+      for (const projectId of expandedProjects) {
+        void loadProjectThreads(projectId);
+      }
+    };
+    appEvents.addEventListener(THREADS_REFRESH_EVENT, handler);
+    return () => appEvents.removeEventListener(THREADS_REFRESH_EVENT, handler);
+  }, [expandedProjects, loadProjectThreads]);
+
+  const handleNewChatInProject = async (projectId: string) => {
+    if (!langGraphClient) return;
+    closeSidebarOnMobile();
+    try {
+      const t = await langGraphClient.threads.create({
+        metadata: { project_id: projectId, graph_id: "giga_agent" },
+      });
+      // Optimistically prepend so the chat appears under the project right away.
+      setProjectThreads((prev) => {
+        const existing = prev[projectId] ?? [];
+        return { ...prev, [projectId]: [t as Thread, ...existing] };
+      });
+      setExpandedProjects((prev) => {
+        if (prev.has(projectId)) return prev;
+        const next = new Set(prev).add(projectId);
+        try {
+          localStorage.setItem(
+            "sidebar_expanded_projects_v1",
+            JSON.stringify(Array.from(next)),
+          );
+        } catch {
+          /* ignore */
+        }
+        return next;
+      });
+      navigate(`/threads/${t.thread_id}`);
+    } catch (e) {
+      console.error("Failed to create chat in project", e);
+    }
+  };
+
   const submitCreateProject = async () => {
     const name = createProjectName.trim();
     if (!name) {
@@ -875,17 +988,87 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
             ) : (
               projects.map((p) => {
                 const isActive = activeProjectId === p.id;
+                const isExpanded = expandedProjects.has(p.id);
+                const childThreads = projectThreads[p.id] ?? [];
+                const childLoading = projectThreadsLoading[p.id] ?? false;
                 return (
-                  <div
-                    key={p.id}
-                    onClick={() => handleOpenProject(p.id)}
-                    className={[
-                      "flex items-center gap-2 px-2 py-1 h-8 text-sm rounded-lg cursor-pointer hover:bg-muted/50",
-                      isActive ? "bg-accent text-accent-foreground" : "",
-                    ].join(" ")}
-                  >
-                    <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    <span className="flex-1 min-w-0 truncate">{p.name}</span>
+                  <div key={p.id}>
+                    <div
+                      className={[
+                        "group flex items-center gap-1 pl-1 pr-1 py-1 h-8 text-sm rounded-lg hover:bg-muted/50",
+                        isActive ? "bg-accent text-accent-foreground" : "",
+                      ].join(" ")}
+                    >
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleProjectExpanded(p.id);
+                        }}
+                        className="h-5 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground shrink-0"
+                        aria-label={isExpanded ? "Свернуть" : "Развернуть"}
+                      >
+                        {isExpanded ? (
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        ) : (
+                          <ChevronRight className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                      <div
+                        onClick={() => handleOpenProject(p.id)}
+                        className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer"
+                      >
+                        <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <span className="flex-1 min-w-0 truncate">
+                          {p.name}
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleNewChatInProject(p.id);
+                        }}
+                        className="h-6 w-6 flex items-center justify-center text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                        aria-label="Новый чат в проекте"
+                        title="Новый чат"
+                      >
+                        <MessageSquarePlus className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                    {isExpanded && (
+                      <div className="ml-5 pl-2 border-l border-border/40 flex flex-col">
+                        {childLoading && childThreads.length === 0 ? (
+                          <div className="px-2 py-1 text-xs text-muted-foreground">
+                            Загрузка…
+                          </div>
+                        ) : childThreads.length === 0 ? (
+                          <div className="px-2 py-1 text-xs text-muted-foreground">
+                            Пока пусто
+                          </div>
+                        ) : (
+                          childThreads.map((t) => {
+                            const title = getThreadTitle(t);
+                            const isActiveThread =
+                              activeThreadId === t.thread_id;
+                            return (
+                              <div
+                                key={t.thread_id}
+                                onClick={() => handleOpenThread(t.thread_id)}
+                                className={[
+                                  "px-2 py-1 h-7 text-xs rounded-lg cursor-pointer truncate hover:bg-muted/50",
+                                  isActiveThread
+                                    ? "bg-accent text-accent-foreground"
+                                    : "",
+                                ].join(" ")}
+                              >
+                                {title}
+                              </div>
+                            );
+                          })
+                        )}
+                      </div>
+                    )}
                   </div>
                 );
               })

--- a/front/src/components/Sidebar.tsx
+++ b/front/src/components/Sidebar.tsx
@@ -1101,11 +1101,13 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                 {threadsError}
               </div>
             )}
-            {!threadsLoading && !threadsError && visibleThreads.length === 0 && (
-              <div className="px-2 py-1 text-sm text-muted-foreground">
-                Нет чатов
-              </div>
-            )}
+            {!threadsLoading &&
+              !threadsError &&
+              visibleThreads.length === 0 && (
+                <div className="px-2 py-1 text-sm text-muted-foreground">
+                  Нет чатов
+                </div>
+              )}
             <div className="flex-1 min-h-0 overflow-auto">
               {threadsLoading && visibleThreads.length === 0 ? (
                 <div className="px-2 py-2 space-y-2">

--- a/front/src/components/Sidebar.tsx
+++ b/front/src/components/Sidebar.tsx
@@ -5,6 +5,8 @@ import {
   ChevronRight,
   Download,
   Files,
+  FolderOpen,
+  FolderPlus,
   Loader2,
   LogOut,
   MoreHorizontal,
@@ -22,6 +24,11 @@ import { useAuth } from "@/components/providers/auth.tsx";
 import type { Thread } from "@langchain/langgraph-sdk";
 import { useLangGraphClient } from "@/hooks/useLangGraphClient";
 import { appEvents, refreshThreads, THREADS_REFRESH_EVENT } from "@/lib/events";
+import {
+  createProject,
+  listProjects,
+  Project,
+} from "@/components/projects/api";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -127,6 +134,19 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
   const [threadsTotal, setThreadsTotal] = useState<number | null>(null);
   const [threadsHasMore, setThreadsHasMore] = useState(false);
   const [threadsRefreshTick, setThreadsRefreshTick] = useState(0);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectsLoading, setProjectsLoading] = useState(false);
+  const [createProjectOpen, setCreateProjectOpen] = useState(false);
+  const [createProjectName, setCreateProjectName] = useState("");
+  const [createProjectSaving, setCreateProjectSaving] = useState(false);
+  const [createProjectError, setCreateProjectError] = useState<string | null>(
+    null,
+  );
+
+  const activeProjectId = useMemo(() => {
+    const match = location.pathname.match(/^\/projects\/([^/?#]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+  }, [location.pathname]);
   const [typedTitles, setTypedTitles] = useState<Record<string, string>>({});
   const [lastSeen, setLastSeen] = useState<Record<string, string>>(() =>
     readLastSeenFromStorage(),
@@ -548,6 +568,54 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
     onNewChat();
   };
 
+  const reloadProjects = React.useCallback(async (signal?: AbortSignal) => {
+    setProjectsLoading(true);
+    try {
+      const list = await listProjects({ signal });
+      setProjects(list);
+    } catch (e) {
+      if (signal?.aborted) return;
+      console.error("Failed to load projects", e);
+    } finally {
+      if (!signal?.aborted) setProjectsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    const ctrl = new AbortController();
+    void reloadProjects(ctrl.signal);
+    return () => ctrl.abort();
+  }, [user, reloadProjects]);
+
+  const handleOpenProject = (projectId: string) => {
+    closeSidebarOnMobile();
+    navigate(`/projects/${projectId}`);
+  };
+
+  const submitCreateProject = async () => {
+    const name = createProjectName.trim();
+    if (!name) {
+      setCreateProjectError("Введите название");
+      return;
+    }
+    setCreateProjectSaving(true);
+    setCreateProjectError(null);
+    try {
+      const created = await createProject({ name });
+      setProjects((prev) => [created, ...prev]);
+      setCreateProjectOpen(false);
+      setCreateProjectName("");
+      navigate(`/projects/${created.id}`);
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error ? e.message : "Не удалось создать проект";
+      setCreateProjectError(message);
+    } finally {
+      setCreateProjectSaving(false);
+    }
+  };
+
   const handleOpenThread = (threadId: string) => {
     closeSidebarOnMobile();
     const opened = threads.find((t) => t.thread_id === threadId);
@@ -764,6 +832,57 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
           >
             <Files size={20} className="mr-2" />
             Документы
+          </div>
+        )}
+
+        <hr className="my-3 border-border/60" />
+
+        {user && (
+          <div className="flex flex-col">
+            <div className="flex items-center justify-between gap-2 px-2 py-1">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                Проекты
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 text-muted-foreground"
+                onClick={() => {
+                  setCreateProjectName("");
+                  setCreateProjectError(null);
+                  setCreateProjectOpen(true);
+                }}
+                aria-label="Создать проект"
+              >
+                <FolderPlus className="h-4 w-4" />
+              </Button>
+            </div>
+            {projectsLoading && projects.length === 0 ? (
+              <div className="px-2 py-1 text-sm text-muted-foreground">
+                Загрузка…
+              </div>
+            ) : projects.length === 0 ? (
+              <div className="px-2 py-1 text-xs text-muted-foreground">
+                Нет проектов
+              </div>
+            ) : (
+              projects.map((p) => {
+                const isActive = activeProjectId === p.id;
+                return (
+                  <div
+                    key={p.id}
+                    onClick={() => handleOpenProject(p.id)}
+                    className={[
+                      "flex items-center gap-2 px-2 py-1 h-8 text-sm rounded-lg cursor-pointer hover:bg-muted/50",
+                      isActive ? "bg-accent text-accent-foreground" : "",
+                    ].join(" ")}
+                  >
+                    <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="flex-1 min-w-0 truncate">{p.name}</span>
+                  </div>
+                );
+              })
+            )}
           </div>
         )}
 
@@ -1064,6 +1183,62 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
       </Dialog>
 
       {/* Rename dialog */}
+      <Dialog
+        open={createProjectOpen}
+        onOpenChange={(open) => {
+          if (createProjectSaving) return;
+          setCreateProjectOpen(open);
+          if (!open) {
+            setCreateProjectName("");
+            setCreateProjectError(null);
+          }
+        }}
+      >
+        <DialogContent
+          onClick={(e) => e.stopPropagation()}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <DialogHeader>
+            <DialogTitle>Новый проект</DialogTitle>
+            <DialogDescription>
+              Проекты группируют чаты и задают общие инструкции для агента.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Input
+              value={createProjectName}
+              onChange={(e) => setCreateProjectName(e.target.value)}
+              placeholder="Название проекта"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void submitCreateProject();
+              }}
+              aria-invalid={Boolean(createProjectError) || undefined}
+            />
+            {createProjectError && (
+              <div className="text-sm text-destructive">
+                {createProjectError}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setCreateProjectOpen(false)}
+              disabled={createProjectSaving}
+            >
+              Отмена
+            </Button>
+            <Button
+              onClick={() => void submitCreateProject()}
+              disabled={createProjectSaving}
+            >
+              {createProjectSaving ? "Создание…" : "Создать"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Dialog
         open={renameOpen}
         onOpenChange={(open) => {

--- a/front/src/components/Sidebar.tsx
+++ b/front/src/components/Sidebar.tsx
@@ -641,6 +641,13 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
     return meta ?? {};
   };
 
+  // Threads that belong to a project are shown under their project, not in
+  // the main "Чаты" list — same as Claude.
+  const visibleThreads = useMemo(
+    () => threads.filter((t) => !getThreadMeta(t).project_id),
+    [threads],
+  );
+
   const getThreadTitle = (t: Thread): string => {
     const meta = getThreadMeta(t);
     const rawTitle =
@@ -911,13 +918,13 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                 {threadsError}
               </div>
             )}
-            {!threadsLoading && !threadsError && threads.length === 0 && (
+            {!threadsLoading && !threadsError && visibleThreads.length === 0 && (
               <div className="px-2 py-1 text-sm text-muted-foreground">
                 Нет чатов
               </div>
             )}
             <div className="flex-1 min-h-0 overflow-auto">
-              {threadsLoading && threads.length === 0 ? (
+              {threadsLoading && visibleThreads.length === 0 ? (
                 <div className="px-2 py-2 space-y-2">
                   {Array.from({ length: 10 }).map((_, i) => (
                     <Skeleton key={i} className="h-9 w-full" />
@@ -925,7 +932,7 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                 </div>
               ) : (
                 <>
-                  {threads.map((t) => {
+                  {visibleThreads.map((t) => {
                     const fullTitle = getThreadTitle(t);
                     const displayTitle = typedTitles[t.thread_id] ?? fullTitle;
                     const isActive = activeThreadId === t.thread_id;
@@ -1075,7 +1082,7 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                       </Button>
                       {threadsTotal !== null && (
                         <div className="mt-1 text-xs text-muted-foreground text-center">
-                          Показано {threads.length} из {threadsTotal}
+                          Показано {visibleThreads.length} из {threadsTotal}
                         </div>
                       )}
                     </div>

--- a/front/src/components/projects/KnowledgeSection.tsx
+++ b/front/src/components/projects/KnowledgeSection.tsx
@@ -1,0 +1,191 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { FileUp, Trash2 } from "lucide-react";
+
+import { API_AGENT_PREFIX } from "@/config.ts";
+import { apiClient, ApiError } from "@/lib/api-client";
+import { Button } from "@/components/ui/button";
+
+const ACCEPTED_FILE_EXTENSIONS = [
+  ".pdf",
+  ".txt",
+  ".md",
+  ".markdown",
+  ".html",
+  ".doc",
+  ".docx",
+];
+
+type DocumentItem = {
+  id: string;
+  metadata?: {
+    name?: string;
+    created_at?: string | null;
+  } | null;
+};
+
+const errorDetail = (e: unknown, fallback: string): string => {
+  if (e instanceof ApiError) return e.message || fallback;
+  if (e instanceof Error) return e.message || fallback;
+  return fallback;
+};
+
+interface Props {
+  collectionId: string | null;
+}
+
+const KnowledgeSection: React.FC<Props> = ({ collectionId }) => {
+  const [documents, setDocuments] = useState<DocumentItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const baseUrl = collectionId
+    ? `${API_AGENT_PREFIX}/rag/collections/${encodeURIComponent(collectionId)}/documents`
+    : null;
+
+  const reload = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!baseUrl) return;
+      setLoading(true);
+      try {
+        const docs = await apiClient.get<DocumentItem[]>(
+          `${baseUrl}?limit=100`,
+          { signal, showError: false },
+        );
+        setDocuments(docs);
+      } catch (e) {
+        if (signal?.aborted) return;
+        console.error("Failed to load knowledge documents", e);
+      } finally {
+        if (!signal?.aborted) setLoading(false);
+      }
+    },
+    [baseUrl],
+  );
+
+  useEffect(() => {
+    if (!baseUrl) return;
+    const ctrl = new AbortController();
+    void reload(ctrl.signal);
+    return () => ctrl.abort();
+  }, [baseUrl, reload]);
+
+  if (!collectionId) {
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="text-sm font-medium">Знания проекта</div>
+        <div className="text-sm text-muted-foreground">
+          Чтобы загружать файлы, сконфигурируйте embedding-модель в настройках —
+          тогда у проекта появится своя коллекция.
+        </div>
+      </div>
+    );
+  }
+
+  const handleFiles = async (fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0 || !baseUrl) return;
+    const files = Array.from(fileList);
+    const metadatas = files.map((file) => ({
+      name: file.name,
+      size: file.size,
+      created_at: new Date().toISOString(),
+    }));
+    const formData = new FormData();
+    files.forEach((file) => formData.append("files", file, file.name));
+    formData.append("metadatas_json", JSON.stringify(metadatas));
+
+    setUploading(true);
+    try {
+      await apiClient.post(baseUrl, formData, { showError: false });
+      toast.success(
+        files.length === 1
+          ? `Загружено: ${files[0].name}`
+          : `Загружено файлов: ${files.length}`,
+      );
+      await reload();
+    } catch (e) {
+      toast.error("Не удалось загрузить", {
+        description: errorDetail(e, "Попробуйте ещё раз."),
+      });
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const handleDelete = async (docId: string) => {
+    if (!baseUrl) return;
+    try {
+      await apiClient.delete(`${baseUrl}/${encodeURIComponent(docId)}`, {
+        showError: false,
+      });
+      setDocuments((prev) => prev.filter((d) => d.id !== docId));
+    } catch (e) {
+      toast.error("Не удалось удалить", {
+        description: errorDetail(e, "Попробуйте ещё раз."),
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium">
+          Знания проекта {documents.length > 0 && `(${documents.length})`}
+        </div>
+        <div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept={ACCEPTED_FILE_EXTENSIONS.join(",")}
+            className="hidden"
+            onChange={(e) => void handleFiles(e.target.files)}
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={uploading}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <FileUp className="w-4 h-4 mr-1" />
+            {uploading ? "Загрузка…" : "Загрузить"}
+          </Button>
+        </div>
+      </div>
+
+      {loading && documents.length === 0 ? (
+        <div className="text-sm text-muted-foreground">Загрузка…</div>
+      ) : documents.length === 0 ? (
+        <div className="text-sm text-muted-foreground">
+          Файлов пока нет. PDF, DOCX, TXT, MD, HTML.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {documents.map((d) => (
+            <div
+              key={d.id}
+              className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg hover:bg-muted text-sm"
+            >
+              <span className="truncate flex-1 min-w-0">
+                {d.metadata?.name ?? "document"}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                onClick={() => void handleDelete(d.id)}
+                aria-label="Удалить"
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default KnowledgeSection;

--- a/front/src/components/projects/KnowledgeSection.tsx
+++ b/front/src/components/projects/KnowledgeSection.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { toast } from "sonner";
-import { FileUp, Trash2 } from "lucide-react";
+import { FileUp, Settings as SettingsIcon, Trash2 } from "lucide-react";
 
 import { API_AGENT_PREFIX } from "@/config.ts";
 import { apiClient, ApiError } from "@/lib/api-client";
@@ -38,7 +39,24 @@ const KnowledgeSection: React.FC<Props> = ({ collectionId }) => {
   const [documents, setDocuments] = useState<DocumentItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [sandboxReady, setSandboxReady] = useState<boolean | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    (async () => {
+      try {
+        const providers = await apiClient.get<unknown[]>(
+          `${API_AGENT_PREFIX}/sandboxes/providers`,
+          { signal: ctrl.signal, showError: false },
+        );
+        if (!ctrl.signal.aborted) setSandboxReady(providers.length > 0);
+      } catch {
+        if (!ctrl.signal.aborted) setSandboxReady(false);
+      }
+    })();
+    return () => ctrl.abort();
+  }, []);
 
   const baseUrl = collectionId
     ? `${API_AGENT_PREFIX}/rag/collections/${encodeURIComponent(collectionId)}/documents`
@@ -143,17 +161,39 @@ const KnowledgeSection: React.FC<Props> = ({ collectionId }) => {
             className="hidden"
             onChange={(e) => void handleFiles(e.target.files)}
           />
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={uploading}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <FileUp className="w-4 h-4 mr-1" />
-            {uploading ? "Загрузка…" : "Загрузить"}
-          </Button>
+          {sandboxReady === false ? (
+            <Button size="sm" variant="outline" asChild>
+              <Link to="/settings/sandbox">
+                <SettingsIcon className="w-4 h-4 mr-1" />
+                Настроить sandbox
+              </Link>
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={uploading || sandboxReady === null}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <FileUp className="w-4 h-4 mr-1" />
+              {uploading ? "Загрузка…" : "Загрузить"}
+            </Button>
+          )}
         </div>
       </div>
+
+      {sandboxReady === false && (
+        <div className="text-xs text-muted-foreground rounded-md bg-muted/50 px-3 py-2">
+          Файлы знаний сохраняются в твой sandbox, а оттуда индексируются.{" "}
+          <Link
+            to="/settings/sandbox"
+            className="underline hover:text-foreground"
+          >
+            Настройте sandbox provider
+          </Link>
+          , чтобы включить загрузку.
+        </div>
+      )}
 
       {loading && documents.length === 0 ? (
         <div className="text-sm text-muted-foreground">Загрузка…</div>

--- a/front/src/components/projects/ProjectPage.tsx
+++ b/front/src/components/projects/ProjectPage.tsx
@@ -31,6 +31,7 @@ import {
   Project,
   updateProject,
 } from "./api";
+import KnowledgeSection from "./KnowledgeSection";
 
 const errorDetail = (e: unknown, fallback: string): string => {
   if (e instanceof ApiError) return e.message || fallback;
@@ -285,6 +286,8 @@ const ProjectPage: React.FC = () => {
             </div>
           </CardContent>
         </Card>
+
+        <KnowledgeSection collectionId={project.collection_id} />
 
         <div className="flex flex-col gap-3">
           <div className="flex items-center justify-between">

--- a/front/src/components/projects/ProjectPage.tsx
+++ b/front/src/components/projects/ProjectPage.tsx
@@ -1,0 +1,329 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import { ArrowLeft, MessageSquarePlus, Trash2 } from "lucide-react";
+import { Client } from "@langchain/langgraph-sdk";
+import type { Thread } from "@langchain/langgraph-sdk";
+
+import { ApiError } from "@/lib/api-client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { useAuth } from "@/components/providers/auth.tsx";
+import { API_BASE_URL } from "@/config.ts";
+import { refreshThreads } from "@/lib/events";
+
+import {
+  deleteProject,
+  getProject,
+  Project,
+  updateProject,
+} from "./api";
+
+const errorDetail = (e: unknown, fallback: string): string => {
+  if (e instanceof ApiError) return e.message || fallback;
+  if (e instanceof Error) return e.message || fallback;
+  return fallback;
+};
+
+const ProjectPage: React.FC = () => {
+  const { projectId } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
+  const { token } = useAuth();
+
+  const [project, setProject] = useState<Project | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [threadsLoading, setThreadsLoading] = useState(false);
+
+  const langGraphClient = useMemo(() => {
+    if (!token) return null;
+    return new Client({
+      apiUrl: API_BASE_URL,
+      apiKey: token,
+      defaultHeaders: { Authorization: `Bearer ${token}` },
+    });
+  }, [token]);
+
+  const loadProject = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!projectId) return;
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const p = await getProject(projectId, { signal });
+        setProject(p);
+        setName(p.name);
+        setDescription(p.description ?? "");
+        setInstructions(p.instructions ?? "");
+      } catch (e) {
+        if (signal?.aborted) return;
+        setLoadError(errorDetail(e, "Не удалось загрузить проект"));
+      } finally {
+        if (!signal?.aborted) setLoading(false);
+      }
+    },
+    [projectId],
+  );
+
+  const loadThreads = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!projectId || !langGraphClient) return;
+      setThreadsLoading(true);
+      try {
+        const result = await langGraphClient.threads.search({
+          metadata: { project_id: projectId },
+          limit: 50,
+          sortBy: "updated_at",
+          sortOrder: "desc",
+          signal,
+        });
+        setThreads(result);
+      } catch (e) {
+        if (signal?.aborted) return;
+        console.error("Failed to load project threads", e);
+      } finally {
+        if (!signal?.aborted) setThreadsLoading(false);
+      }
+    },
+    [projectId, langGraphClient],
+  );
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void loadProject(ctrl.signal);
+    return () => ctrl.abort();
+  }, [loadProject]);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void loadThreads(ctrl.signal);
+    return () => ctrl.abort();
+  }, [loadThreads]);
+
+  const dirty = useMemo(() => {
+    if (!project) return false;
+    return (
+      name !== project.name ||
+      description !== (project.description ?? "") ||
+      instructions !== (project.instructions ?? "")
+    );
+  }, [project, name, description, instructions]);
+
+  const save = async () => {
+    if (!project) return;
+    if (!name.trim()) {
+      toast.error("Название не может быть пустым");
+      return;
+    }
+    setSaving(true);
+    try {
+      const updated = await updateProject(project.id, {
+        name: name.trim(),
+        description: description.trim() || null,
+        instructions: instructions.trim() || null,
+      });
+      setProject(updated);
+      toast.success("Проект сохранён");
+    } catch (e) {
+      toast.error("Не удалось сохранить", {
+        description: errorDetail(e, "Попробуйте ещё раз."),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!project) return;
+    try {
+      await deleteProject(project.id);
+      toast.success("Проект удалён");
+      navigate("/");
+    } catch (e) {
+      toast.error("Не удалось удалить", {
+        description: errorDetail(e, "Попробуйте ещё раз."),
+      });
+    }
+  };
+
+  const startNewChat = async () => {
+    if (!project || !langGraphClient) return;
+    try {
+      const t = await langGraphClient.threads.create({
+        metadata: {
+          project_id: project.id,
+          graph_id: "giga_agent",
+        },
+      });
+      refreshThreads();
+      navigate(`/threads/${t.thread_id}`);
+    } catch (e) {
+      toast.error("Не удалось создать чат", {
+        description: errorDetail(e, "Попробуйте ещё раз."),
+      });
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex-1 p-6 text-muted-foreground">Загрузка проекта…</div>
+    );
+  }
+
+  if (loadError || !project) {
+    return (
+      <div className="flex-1 p-6">
+        <div className="text-red-500 mb-3">
+          {loadError ?? "Проект не найден"}
+        </div>
+        <Button variant="outline" onClick={() => navigate("/")}>
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          На главную
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-3xl mx-auto p-6 flex flex-col gap-6">
+        <div className="flex items-center justify-between gap-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate("/")}
+            className="-ml-2"
+          >
+            <ArrowLeft className="w-4 h-4 mr-1" />
+            Назад
+          </Button>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="ghost" size="sm" className="text-red-500">
+                <Trash2 className="w-4 h-4 mr-1" />
+                Удалить
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Удалить проект?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Чаты, привязанные к проекту, останутся, но потеряют связь.
+                  Действие нельзя отменить.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Отмена</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleDelete}
+                  className="bg-red-500 hover:bg-red-600"
+                >
+                  Удалить
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+
+        <Card>
+          <CardContent className="p-5 flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <label className="text-xs uppercase text-muted-foreground">
+                Название
+              </label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Название проекта"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs uppercase text-muted-foreground">
+                Описание
+              </label>
+              <Input
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Краткое описание (опционально)"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs uppercase text-muted-foreground">
+                Инструкции для агента
+              </label>
+              <Textarea
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="Эти инструкции будут добавляться к системному промпту во всех чатах проекта."
+                className="min-h-[200px] font-mono text-sm"
+              />
+            </div>
+            <div className="flex justify-end">
+              <Button onClick={save} disabled={!dirty || saving}>
+                {saving ? "Сохранение…" : "Сохранить"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-medium">
+              Чаты в проекте {threads.length > 0 && `(${threads.length})`}
+            </div>
+            <Button size="sm" onClick={startNewChat}>
+              <MessageSquarePlus className="w-4 h-4 mr-1" />
+              Новый чат
+            </Button>
+          </div>
+          {threadsLoading ? (
+            <div className="text-sm text-muted-foreground">Загрузка чатов…</div>
+          ) : threads.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              Пока ни одного чата. Создайте первый.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1">
+              {threads.map((t) => {
+                const title =
+                  (t.metadata?.thread_title as string | undefined) ??
+                  "Без названия";
+                return (
+                  <div
+                    key={t.thread_id}
+                    onClick={() => navigate(`/threads/${t.thread_id}`)}
+                    className="px-3 py-2 rounded-lg hover:bg-muted cursor-pointer text-sm truncate"
+                  >
+                    {title}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectPage;

--- a/front/src/components/projects/ProjectPage.tsx
+++ b/front/src/components/projects/ProjectPage.tsx
@@ -25,12 +25,7 @@ import { useAuth } from "@/components/providers/auth.tsx";
 import { API_BASE_URL } from "@/config.ts";
 import { refreshThreads } from "@/lib/events";
 
-import {
-  deleteProject,
-  getProject,
-  Project,
-  updateProject,
-} from "./api";
+import { deleteProject, getProject, Project, updateProject } from "./api";
 import KnowledgeSection from "./KnowledgeSection";
 
 const errorDetail = (e: unknown, fallback: string): string => {

--- a/front/src/components/projects/api.ts
+++ b/front/src/components/projects/api.ts
@@ -1,0 +1,62 @@
+import { API_AGENT_PREFIX } from "@/config.ts";
+import { apiClient } from "@/lib/api-client";
+
+export const PROJECTS_API_PREFIX = `${API_AGENT_PREFIX}/projects`;
+
+export type Project = {
+  id: string;
+  owner_id: string;
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  collection_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProjectCreate = {
+  name: string;
+  description?: string | null;
+  instructions?: string | null;
+};
+
+export type ProjectUpdate = {
+  name?: string;
+  description?: string | null;
+  instructions?: string | null;
+};
+
+export const listProjects = (options?: {
+  signal?: AbortSignal;
+}): Promise<Project[]> =>
+  apiClient.get<Project[]>(`${PROJECTS_API_PREFIX}/`, {
+    showError: false,
+    signal: options?.signal,
+  });
+
+export const getProject = (
+  projectId: string,
+  options?: { signal?: AbortSignal },
+): Promise<Project> =>
+  apiClient.get<Project>(`${PROJECTS_API_PREFIX}/${projectId}`, {
+    showError: false,
+    signal: options?.signal,
+  });
+
+export const createProject = (payload: ProjectCreate): Promise<Project> =>
+  apiClient.post<Project>(`${PROJECTS_API_PREFIX}/`, payload, {
+    showError: false,
+  });
+
+export const updateProject = (
+  projectId: string,
+  payload: ProjectUpdate,
+): Promise<Project> =>
+  apiClient.patch<Project>(`${PROJECTS_API_PREFIX}/${projectId}`, payload, {
+    showError: false,
+  });
+
+export const deleteProject = (projectId: string): Promise<void> =>
+  apiClient.delete<void>(`${PROJECTS_API_PREFIX}/${projectId}`, {
+    showError: false,
+  });

--- a/front/src/components/projects/useThreadProject.ts
+++ b/front/src/components/projects/useThreadProject.ts
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useState } from "react";
+import { Client } from "@langchain/langgraph-sdk";
+
+import { useAuth } from "@/components/providers/auth.tsx";
+import { API_BASE_URL } from "@/config.ts";
+
+import { getProject, Project } from "./api";
+
+/**
+ * Resolve which Project a LangGraph thread belongs to.
+ *
+ * Reads thread.metadata.project_id via LangGraph SDK, then fetches the
+ * project record. Returns null when the thread isn't part of any project.
+ */
+export function useThreadProject(threadId: string | undefined | null) {
+  const { token } = useAuth();
+  const [project, setProject] = useState<Project | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const langGraphClient = useMemo(() => {
+    if (!token) return null;
+    return new Client({
+      apiUrl: API_BASE_URL,
+      apiKey: token,
+      defaultHeaders: { Authorization: `Bearer ${token}` },
+    });
+  }, [token]);
+
+  useEffect(() => {
+    if (!threadId || !langGraphClient) {
+      setProject(null);
+      return;
+    }
+    const ctrl = new AbortController();
+    setLoading(true);
+    (async () => {
+      try {
+        const thread = await langGraphClient.threads.get(threadId);
+        const projectId = (thread.metadata as { project_id?: string } | null)
+          ?.project_id;
+        if (!projectId) {
+          if (!ctrl.signal.aborted) setProject(null);
+          return;
+        }
+        const p = await getProject(projectId, { signal: ctrl.signal });
+        if (!ctrl.signal.aborted) setProject(p);
+      } catch (e) {
+        if (ctrl.signal.aborted) return;
+        console.error("useThreadProject: failed", e);
+        setProject(null);
+      } finally {
+        if (!ctrl.signal.aborted) setLoading(false);
+      }
+    })();
+    return () => ctrl.abort();
+  }, [threadId, langGraphClient]);
+
+  return { project, loading };
+}


### PR DESCRIPTION
## Summary

Adds Claude-style **Projects** — a way to group threads under a named workspace with shared custom instructions and its own RAG knowledge base.

- **Backend**: new `core_projects` table (owner-scoped, unique name), CRUD at `/api/agent/projects`, auto-created backing RAG collection per project (hidden from the global collection list).
- **Agent prompt**: `ProjectsModule` reads `project_id` from the LangGraph thread metadata and appends the project's instructions to the system prompt. `RagModule` surfaces the project's collection to the agent so `get_documents()` can search uploaded files.
- **Frontend**: `/projects/:id` page (name / description / instructions editor, threads list, knowledge upload), sidebar section with expandable folders, inline "new chat in project" button, project chip in the input toolbar.
- **UX polish**: project-bound threads hidden from the main "Чаты" list, sandbox-setup hint when uploads aren't possible, legacy projects lazily get their collection on next open.

Includes one drive-by chore: `chore(front): bump TS lib to ES2023` — fixes the v0.2 production frontend build that broke on `Array.prototype.findLast()`. Happy to split into its own PR if preferred.

13 commits, alembic migration `9a4f8d2e1c3b`, 18 backend tests covering CRUD, prompt injection, lazy collection creation, RAG merge.

## Test plan

- [ ] `uv run giga_agent migrate` applies the new migration cleanly
- [ ] Create a project, set instructions, create a chat in it — agent picks up the instructions in the system prompt
- [ ] Upload a knowledge file (PDF/DOCX/TXT/MD) — `get_documents` finds it in a project chat
- [ ] Existing chats (no `project_id`) keep working and show up in the main list as before
- [ ] Sidebar: expandable project folders, inline new-chat button, project chip in input
- [ ] Delete project — backing collection is cleaned up, orphan threads keep working
- [ ] Legacy project created before embedding was configured: opening it now creates the backing collection automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)