### PR TITLE
UI polish: типографика, радиусы, brand-акцент, активный сайдбар

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ agents_md
 .claude
 .debug/
 .playwright-cli/
+.gstack/
+.env.giga_agent

--- a/front/index.html
+++ b/front/index.html
@@ -4,6 +4,9 @@
     <base href="%BASE_URL%"/>
     <meta charset="UTF-8"/>
     <link rel="icon" type="image/svg+xml" href="./icon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Golos+Text:wght@400;500;600;700&display=swap"/>
     <meta name="theme-color" content="#1f1f1f">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="theme-color" content="#000000"/>
@@ -69,7 +72,7 @@
         }
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            font-family: 'Golos Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
             margin: 0;
             padding: 0;
             min-height: 100vh;

--- a/front/src/components/InputArea.tsx
+++ b/front/src/components/InputArea.tsx
@@ -1156,7 +1156,7 @@ const InputArea: React.FC<InputAreaProps> = ({ thread }) => {
           </div>
           <label
             data-onboarding="autonomy-switch"
-            className="absolute top-0 right-0 flex items-center gap-2 select-none text-[11px] text-muted-foreground leading-none"
+            className="absolute top-2 right-3 flex items-center gap-2 select-none text-[11px] text-muted-foreground leading-none"
           >
             <span>Автономность</span>
             <Switch

--- a/front/src/components/Message.tsx
+++ b/front/src/components/Message.tsx
@@ -514,7 +514,7 @@ const Message: React.FC<MessageProps> = ({
             <div
               className={[
                 message.type === "human"
-                  ? "max-w-[80%] w-auto p-4 pt-4 pb-4 rounded-[25px] bg-secondary text-foreground overflow-x-auto"
+                  ? "max-w-[78%] w-auto px-4 py-3 rounded-2xl bg-secondary text-foreground overflow-x-auto"
                   : "max-w-full w-full p-0 bg-transparent",
                 "markdown",
               ].join(" ")}

--- a/front/src/components/Sidebar.tsx
+++ b/front/src/components/Sidebar.tsx
@@ -833,7 +833,7 @@ const SidebarComponent = ({ onNewChat }: SidebarProps) => {
                         className={[
                           "group relative px-2 py-1 h-10 text-sm rounded-lg cursor-pointer transition-colors flex items-center gap-2",
                           isActive
-                            ? "bg-accent text-accent-foreground border border-border"
+                            ? "bg-brand/10 text-foreground border border-brand/30"
                             : "hover:bg-muted/50",
                         ].join(" ")}
                         onClick={() => handleOpenThread(t.thread_id)}

--- a/front/src/components/wellcome-message.tsx
+++ b/front/src/components/wellcome-message.tsx
@@ -90,6 +90,12 @@ const WellcomeMessage: React.FC = () => {
           variants={logoVariants}
           aria-label="GigaAgent Logo"
         />
+        <motion.p
+          className="mt-5 text-lg text-muted-foreground"
+          variants={itemVariants}
+        >
+          Чем помочь сегодня?
+        </motion.p>
       </motion.div>
     </div>
   );

--- a/front/src/style.css
+++ b/front/src/style.css
@@ -39,6 +39,8 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.87 0 0);
   --highlight: oklch(0 0 0 / 0.14);
+  --brand: oklch(0.63 0.15 150);
+  --brand-foreground: oklch(0.985 0 0);
 }
 
 .dark {
@@ -78,6 +80,8 @@
     inset 0 1px 2px oklch(1 0 0 / 0.2), 0 1px 2px oklch(0 0 0 / 0.3),
     0 2px 4px oklch(0 0 0 / 0.15);
   --highlight: oklch(1 0 0 / 0.14);
+  --brand: oklch(0.7 0.14 150);
+  --brand-foreground: oklch(0.16 0 0);
 }
 
 @theme inline {
@@ -120,6 +124,8 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-highlight: var(--highlight);
+  --color-brand: var(--brand);
+  --color-brand-foreground: var(--brand-foreground);
 }
 
 @layer base {

--- a/front/src/style.css
+++ b/front/src/style.css
@@ -81,6 +81,8 @@
 }
 
 @theme inline {
+  --font-sans: "Golos Text", ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
## Зачем
UI выглядел «вроде просто, но криво». Причина — не одна ошибка, а рассогласование мелочей: системный шрифт без своей типографики, разнобой радиусов скругления, чисто-серая тема со случайным зелёным, невидимый active-стейт в сайдбаре.

Полный визуальный аудит + точечные фиксы (CSS-first, по одному коммиту на находку).

## Изменения
| Находка | Было → Стало |
|---|---|
| **Типографика** | системный `system-ui` → **Golos Text** (кириллический, Paratype). Главный драйвер «плоскости» |
| **Радиусы** | `rounded-[25px]` пузырь выпадал → сведено к шкале (`rounded-2xl`), padding тоньше |
| **Акцент** | случайный зелёный → токен `--brand` (Sber green) в `:root`/`.dark`/`@theme` |
| **Сайдбар** | активный тред `bg-accent` ≈ невидим → brand-тинт + рамка |
| **Пустой экран** | только вордмарк → приветствие «Чем помочь сегодня?» |
| **Инпут** | тумблер автономности в углу → отступ от края |

## Проверка
- Сборка задеплоена, проверено вживую на desktop (1440px)
- Golos Text в проде, brand-токен резолвится в зелёный
- Консоль без ошибок, верстка цела

Дизайн-аудит и before/after — локально в `~/.gstack/projects/.../designs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)