### PR TITLE
feat: describe disabled modules in system prompt

### DIFF
--- a/backend/giga_agent/core/agent/base.py
+++ b/backend/giga_agent/core/agent/base.py
@@ -303,14 +303,26 @@ class BaseAgent(BaseModel):
     ) -> str:
         disabled = _disabled_module_ids(config, user)
         modules_prompts = []
+        disabled_modules: list[BaseModule] = []
         for module in self._agent_modules:
             if module.label and module.id in disabled:
+                disabled_modules.append(module)
                 continue
             instructions = await module.get_instructions(
                 user=user, agent=self, state=state, config=config
             )
             if instructions:
                 modules_prompts.append(instructions)
+        # Выключенные пользователем модули: даём модели знать об их
+        # существовании и как их подключить, но без байндинга тулов.
+        if disabled_modules:
+            from giga_agent.core.agent.disabled_modules_prompt import (
+                build_disabled_modules_prompt,
+            )
+
+            disabled_prompt = build_disabled_modules_prompt(disabled_modules)
+            if disabled_prompt:
+                modules_prompts.append(disabled_prompt)
         # Несъёмный connector-дисптач: единый листинг доступных коннекторов
         # (MCP-серверы + ленивые модули). Источники вычисляются один раз в
         # amodel_node и передаются сюда, чтобы не дублировать запросы.
@@ -335,10 +347,6 @@ class BaseAgent(BaseModel):
         base_prompt = await build_base_prompt(
             enable_think=enable_think,
             enable_multi_tool_use=enable_multi_tool_use,
-        )
-        pr = (
-            base_prompt.format(modules="\n===\n\n".join(modules_prompts))
-            + instructions_prompt
         )
         return (
             base_prompt.format(modules="\n===\n\n".join(modules_prompts))

--- a/backend/giga_agent/core/agent/disabled_modules_prompt.py
+++ b/backend/giga_agent/core/agent/disabled_modules_prompt.py
@@ -1,0 +1,80 @@
+"""System-prompt section describing modules the user has toggled off.
+
+Отключённые пользователем модули (``disabled_modules``) не байндят свои тулы и
+не добавляют инструкции. Но модель полезно знать, что такие возможности
+*существуют*, но выключены, — чтобы вместо неудачной попытки выполнить действие
+она могла подсказать пользователю включить нужный модуль и что для этого нужно
+(какие креды/интеграции подключить).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from giga_agent.core.module import BaseModule
+
+
+def _connect_hint(module: "BaseModule") -> str:
+    """Короткая подсказка «что нужно, чтобы подключить модуль».
+
+    Собирается из объявленных модулем секретов (``get_secrets``) и интеграций
+    (``get_providers``). Best-effort: любые ошибки построения игнорируются, чтобы
+    один сбойный модуль не ломал весь системный промпт.
+    """
+    parts: list[str] = []
+
+    try:
+        for secret in module.get_secrets():
+            name = (secret.get("name") or "").strip()
+            if not name:
+                continue
+            desc = (secret.get("description") or "").strip()
+            parts.append(f"{name} — {desc}" if desc else name)
+    except Exception:  # noqa: BLE001 — подсказка не должна ломать промпт
+        pass
+
+    try:
+        for provider in module.get_providers():
+            label = (getattr(provider, "label", "") or "").strip()
+            if label:
+                parts.append(f"интеграция «{label}»")
+    except Exception:  # noqa: BLE001 — подсказка не должна ломать промпт
+        pass
+
+    return "; ".join(parts)
+
+
+def build_disabled_modules_prompt(modules: "list[BaseModule]") -> str | None:
+    """Render the «Отключённые модули» block, or ``None`` if there are none.
+
+    *modules* — уже отфильтрованный список пользовательских (``label`` непустой)
+    модулей, отключённых через ``disabled_modules``.
+    """
+    lines: list[str] = []
+    for module in modules:
+        label = (module.label or "").strip()
+        if not label:
+            continue
+        description = (module.description or "").strip()
+        head = f"- {label}"
+        if description:
+            head = f"{head}: {description}"
+        hint = _connect_hint(module)
+        if hint:
+            head = f"{head} Чтобы подключить, нужно: {hint}."
+        lines.append(head)
+
+    if not lines:
+        return None
+
+    listing = "\n".join(lines)
+    return (
+        "Отключённые модули (сейчас НЕДОСТУПНЫ — их инструменты выключены "
+        "пользователем):\n"
+        f"{listing}\n"
+        "Не пытайся выполнять действия этих модулей — их инструментов нет. "
+        "Если задача пользователя требует одного из них, сообщи, что нужно "
+        "включить соответствующий модуль в настройках, и подскажи, что для "
+        "этого нужно подключить."
+    )

--- a/backend/tests/core/test_disabled_modules_prompt.py
+++ b/backend/tests/core/test_disabled_modules_prompt.py
@@ -1,0 +1,74 @@
+from giga_agent.core.agent.disabled_modules_prompt import (
+    build_disabled_modules_prompt,
+)
+from giga_agent.core.module import BaseModule, SecretMetadata
+
+
+class _PlainModule(BaseModule):
+    id: str = "plain"
+    label: str = "Погода"
+    description: str = "Получение прогноза погоды"
+
+
+class _SecretModule(BaseModule):
+    id: str = "weather"
+    label: str = "Погода"
+    description: str = "Получение прогноза погоды"
+
+    def get_secrets(self, **kwargs) -> list[SecretMetadata]:
+        return [
+            {
+                "name": "OWM_API_KEY",
+                "description": "API key OpenWeatherMap",
+                "type": "pass",
+            }
+        ]
+
+
+class _ProviderModule(BaseModule):
+    id: str = "yandex_disk"
+    label: str = "Яндекс.Диск"
+    description: str = "Работа с файлами на Яндекс.Диске"
+
+    def get_providers(self, **kwargs):
+        class _Provider:
+            label = "Яндекс.Диск"
+
+        return [_Provider()]
+
+
+class _ServiceModule(BaseModule):
+    id: str = "service"
+    label: str = ""
+    description: str = "Служебный модуль"
+
+
+def test_returns_none_for_empty_list():
+    assert build_disabled_modules_prompt([]) is None
+
+
+def test_lists_label_and_description():
+    prompt = build_disabled_modules_prompt([_PlainModule()])
+    assert prompt is not None
+    assert "Погода" in prompt
+    assert "Получение прогноза погоды" in prompt
+    assert "Отключённые модули" in prompt
+
+
+def test_includes_secret_connect_hint():
+    prompt = build_disabled_modules_prompt([_SecretModule()])
+    assert prompt is not None
+    assert "OWM_API_KEY" in prompt
+    assert "API key OpenWeatherMap" in prompt
+    assert "подключить" in prompt.lower()
+
+
+def test_includes_provider_connect_hint():
+    prompt = build_disabled_modules_prompt([_ProviderModule()])
+    assert prompt is not None
+    assert "Яндекс.Диск" in prompt
+    assert "интеграция" in prompt.lower()
+
+
+def test_skips_service_modules_without_label():
+    assert build_disabled_modules_prompt([_ServiceModule()]) is None


### PR DESCRIPTION
## Description
Modules a user has toggled off previously vanished from the system prompt entirely. This adds a compact "disabled modules" section listing each off module's name, short description, and a hint about what needs connecting (secrets / integrations) to enable it — so the model can guide the user to turn on the right module instead of failing to call a missing tool. Tools of disabled modules are still not bound.

## Release Note
The agent now knows about modules the user has disabled and can suggest enabling them (with what's needed to connect) instead of silently failing.

## Test Plan
- [ ] With a user-facing module toggled off, start a chat and confirm the system prompt contains the "Отключённые модули" block with the module name/description and connect hint, while its tools remain unavailable.

Made by [Open SWE](https://github.com/langchain-ai/open-swe)