### PR TITLE
[Draft] Команды: приглашения, роли, общие ресурсы и учёт использования

### DIFF
--- a/backend/giga_agent/core/agent/base.py
+++ b/backend/giga_agent/core/agent/base.py
@@ -235,11 +235,14 @@ class BaseAgent(BaseModel):
                 )
 
         # Собираем middleware из модулей
+        from giga_agent.middlewares.usage_tracking import UsageTrackingMiddleware
+
         module_middlewares = self._get_module_middlewares()
         all_middleware = [
             RepairMessagesMiddleware(),
             ThreadTitleMiddleware(),
             ToolResultMiddleware(),
+            UsageTrackingMiddleware(),
             *module_middlewares,
         ]
 

--- a/backend/giga_agent/core/team.py
+++ b/backend/giga_agent/core/team.py
@@ -1,0 +1,132 @@
+"""Команда инстанса: системная группа «All Members».
+
+Инстанс GigaAgent = одна команда. Системная группа объединяет всех
+пользователей; членство автоматическое (создание юзера/вступление по
+инвайту), выход и удаление группы запрещены. Ресурс, расшаренный на эту
+группу (ResourcePermission read), становится «доступен команде».
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from giga_agent.core.events import event_bus
+from giga_agent.core.logging import get_logger
+from giga_agent.models.group import Group, GroupMember
+from giga_agent.models.users import User
+
+logger = get_logger(__name__)
+
+# Маркер системной группы в Group.data.
+SYSTEM_GROUP_ALL_MEMBERS = "all_members"
+ALL_MEMBERS_NAME = "All Members"
+
+_SUBSCRIBED = False
+_LOCK = asyncio.Lock()
+
+
+def is_system_group(group: Group) -> bool:
+    data = group.data if isinstance(group.data, dict) else {}
+    return data.get("system") == SYSTEM_GROUP_ALL_MEMBERS
+
+
+async def find_all_members_group(session: AsyncSession) -> Group | None:
+    result = await session.execute(select(Group))
+    for group in result.scalars().all():
+        if is_system_group(group):
+            return group
+    return None
+
+
+async def _backfill_members(session: AsyncSession, group_id: uuid.UUID) -> int:
+    """Добавляет в группу всех пользователей, которых там ещё нет."""
+    existing = {
+        row[0]
+        for row in (
+            await session.execute(
+                select(GroupMember.user_id).where(GroupMember.group_id == group_id)
+            )
+        ).all()
+    }
+    all_ids = [row[0] for row in (await session.execute(select(User.id))).all()]
+    missing = [uid for uid in all_ids if uid not in existing]
+    for uid in missing:
+        session.add(GroupMember(group_id=group_id, user_id=uid))
+    return len(missing)
+
+
+async def ensure_all_members_group(session: AsyncSession) -> Group:
+    """Создаёт системную группу при первом старте и бэкфиллит членство.
+
+    Идемпотентно: повторные вызовы ничего не ломают.
+    """
+    group = await find_all_members_group(session)
+    if group is None:
+        # Владелец группы — owner инстанса (или самый ранний пользователь).
+        owner_row = await session.execute(
+            select(User.id)
+            .order_by((User.role != "owner").asc(), User.created_at.asc())
+            .limit(1)
+        )
+        owner_id = owner_row.scalar_one_or_none()
+        if owner_id is None:
+            raise RuntimeError("Cannot create All Members group: no users exist")
+        group = Group(
+            owner_id=owner_id,
+            name=ALL_MEMBERS_NAME,
+            description="Все участники команды (системная группа)",
+            data={"system": SYSTEM_GROUP_ALL_MEMBERS},
+        )
+        session.add(group)
+        await session.flush()
+        logger.info("Created system group 'All Members' (%s)", group.id)
+
+    added = await _backfill_members(session, group.id)
+    await session.commit()
+    if added:
+        logger.info("All Members: backfilled %d member(s)", added)
+    return group
+
+
+async def _handle_user_created(event) -> None:
+    """Новый пользователь автоматически попадает в All Members."""
+    from giga_agent.core.db import get_session_factory
+
+    try:
+        factory = await get_session_factory()
+        async with factory() as session:
+            group = await find_all_members_group(session)
+            if group is None:
+                group = await ensure_all_members_group(session)
+                return  # ensure уже добавил всех, включая нового
+            exists = await session.execute(
+                select(GroupMember).where(
+                    GroupMember.group_id == group.id,
+                    GroupMember.user_id == event.user_id,
+                )
+            )
+            if exists.scalar_one_or_none() is None:
+                session.add(
+                    GroupMember(group_id=group.id, user_id=event.user_id)
+                )
+                await session.commit()
+    except Exception:
+        logger.exception(
+            "Failed to add user %s to All Members", getattr(event, "user_id", "?")
+        )
+
+
+async def ensure_subscribed() -> None:
+    """Подписка на UserCreatedEvent (однократная)."""
+    from giga_agent.modules.auth.events import UserCreatedEvent
+
+    global _SUBSCRIBED
+    async with _LOCK:
+        if _SUBSCRIBED:
+            return
+        event_bus.subscribe(UserCreatedEvent, _handle_user_created)
+        _SUBSCRIBED = True

--- a/backend/giga_agent/middlewares/usage_tracking.py
+++ b/backend/giga_agent/middlewares/usage_tracking.py
@@ -1,0 +1,82 @@
+"""Учёт использования LLM: пишет usage_metadata каждого ответа модели.
+
+Fire-and-forget: любая ошибка учёта логируется и не влияет на ответ.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.runtime import Runtime
+
+from giga_agent.core.agent.middleware import AgentMiddleware
+from giga_agent.core.agent.types import AgentState, Context
+from giga_agent.core.logging import get_logger
+from giga_agent.utils.langgraph_sdk import get_user_id_from_config
+
+logger = get_logger(__name__)
+
+
+def _resolve_user_id(config: RunnableConfig | dict[str, Any]) -> uuid.UUID | None:
+    identity = get_user_id_from_config(config)
+    if isinstance(identity, uuid.UUID):
+        return identity
+    if isinstance(identity, str):
+        try:
+            return uuid.UUID(identity)
+        except ValueError:
+            return None
+    return None
+
+
+async def _record(user_id: uuid.UUID, model: str | None, usage: dict) -> None:
+    try:
+        from giga_agent.core.db import get_session_factory
+        from giga_agent.models.usage import UsageEvent
+
+        factory = await get_session_factory()
+        async with factory() as session:
+            session.add(
+                UsageEvent(
+                    user_id=user_id,
+                    model=(model or None),
+                    input_tokens=int(usage.get("input_tokens") or 0),
+                    output_tokens=int(usage.get("output_tokens") or 0),
+                )
+            )
+            await session.commit()
+    except Exception:
+        logger.exception("UsageTracking: failed to record usage")
+
+
+class UsageTrackingMiddleware(AgentMiddleware):
+    async def after_model(
+        self,
+        state: AgentState,
+        runtime: Runtime[Context],
+        config: RunnableConfig,
+    ) -> dict[str, Any] | None:
+        _ = runtime
+        try:
+            message = state["messages"][-1] if state.get("messages") else None
+            if not isinstance(message, AIMessage):
+                return None
+            usage = getattr(message, "usage_metadata", None)
+            if not usage:
+                return None
+            user_id = _resolve_user_id(config)
+            if user_id is None:
+                return None
+            model = None
+            meta = getattr(message, "response_metadata", None)
+            if isinstance(meta, dict):
+                model = meta.get("model_name") or meta.get("model")
+            # Не задерживаем основной поток записью в БД.
+            asyncio.create_task(_record(user_id, model, dict(usage)))
+        except Exception:
+            logger.exception("UsageTracking: after_model failed")
+        return None

--- a/backend/giga_agent/models/invite.py
+++ b/backend/giga_agent/models/invite.py
@@ -1,0 +1,232 @@
+"""Приглашения в команду (инстанс = одна команда).
+
+Флоу: админ создаёт инвайт → получает ссылку /join/<token> (токен показывается
+один раз, в БД хранится только SHA-256 хэш) → приглашённый открывает ссылку,
+задаёт email/пароль и попадает в команду с ролью и группами из инвайта.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets as _secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Literal, Optional
+
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Uuid,
+    select,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from giga_agent.core.db import Base, JSON_VARIANT
+
+DEFAULT_INVITE_TTL_DAYS = 7
+
+
+def generate_invite_token() -> str:
+    """URL-safe токен приглашения (возвращается пользователю один раз)."""
+    return _secrets.token_urlsafe(32)
+
+
+def hash_invite_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class Invite(Base):
+    __tablename__ = "core_invites"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, primary_key=True, index=True, default=uuid.uuid4
+    )
+    token_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True, index=True
+    )
+    # Если задан — принять приглашение можно только с этой почтой.
+    email: Mapped[str | None] = mapped_column(String, nullable=True)
+    role: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="member", server_default="member"
+    )
+    group_ids: Mapped[list | None] = mapped_column(
+        JSON_VARIANT(), nullable=True, default=None
+    )
+    # Онбординг «вошёл и работает»: скопировать runtime-ссылки (llm_id и пр.)
+    # создателя инвайта + выдать read-права на них (как в админ-создании юзера).
+    copy_runtime_ids: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+    copy_module_secrets: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    max_uses: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    used_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("core_users.id", name="fk_core_invites_created_by"),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), server_default=func.now()
+    )
+
+    def is_usable(self, now: datetime | None = None) -> tuple[bool, str]:
+        """(usable, причина-код). Причина не раскрывается публично."""
+        now = now or datetime.now(timezone.utc)
+        if self.revoked_at is not None:
+            return False, "revoked"
+        if self.expires_at is not None and self.expires_at <= now:
+            return False, "expired"
+        if self.used_count >= self.max_uses:
+            return False, "exhausted"
+        return True, "ok"
+
+
+# ============ Pydantic Schemas ============
+
+
+class InviteCreate(BaseModel):
+    email: Optional[EmailStr] = None
+    role: Literal["member", "admin"] = "member"
+    group_ids: list[uuid.UUID] = Field(default_factory=list)
+    copy_runtime_ids: bool = True
+    copy_module_secrets: bool = False
+    max_uses: int = Field(default=1, ge=1, le=1000)
+    expires_in_days: int = Field(default=DEFAULT_INVITE_TTL_DAYS, ge=1, le=90)
+
+
+class InviteResponse(BaseModel):
+    id: uuid.UUID
+    email: Optional[str] = None
+    role: str
+    group_ids: list[uuid.UUID] = Field(default_factory=list)
+    copy_runtime_ids: bool
+    copy_module_secrets: bool
+    max_uses: int
+    used_count: int
+    expires_at: datetime
+    revoked_at: Optional[datetime] = None
+    created_by: uuid.UUID
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class InviteCreatedResponse(InviteResponse):
+    """Ответ на создание: содержит токен — показывается ровно один раз."""
+
+    token: str
+    join_path: str
+
+
+class JoinInfo(BaseModel):
+    """Публичная информация о приглашении для страницы /join/<token>."""
+
+    valid: bool
+    email: Optional[str] = None  # если задан — поле почты фиксировано
+    role: Optional[str] = None
+
+
+class JoinRequest(BaseModel):
+    token: str
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=256)
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+
+
+# ============ Repository ============
+
+
+class InviteRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create(
+        self,
+        *,
+        data: InviteCreate,
+        created_by: uuid.UUID,
+        commit: bool = True,
+    ) -> tuple[Invite, str]:
+        token = generate_invite_token()
+        invite = Invite(
+            token_hash=hash_invite_token(token),
+            email=str(data.email) if data.email else None,
+            role=data.role,
+            group_ids=[str(gid) for gid in data.group_ids],
+            copy_runtime_ids=data.copy_runtime_ids,
+            copy_module_secrets=data.copy_module_secrets,
+            max_uses=data.max_uses,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=data.expires_in_days),
+            created_by=created_by,
+        )
+        self.db.add(invite)
+        if commit:
+            await self.db.commit()
+        else:
+            await self.db.flush()
+        await self.db.refresh(invite)
+        return invite, token
+
+    async def get_all(self) -> list[Invite]:
+        result = await self.db.execute(
+            select(Invite).order_by(Invite.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def get_by_id(self, invite_id: uuid.UUID) -> Invite | None:
+        result = await self.db.execute(select(Invite).where(Invite.id == invite_id))
+        return result.scalar_one_or_none()
+
+    async def get_by_token(self, token: str) -> Invite | None:
+        result = await self.db.execute(
+            select(Invite).where(Invite.token_hash == hash_invite_token(token))
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_token_for_update(self, token: str) -> Invite | None:
+        """Строчная блокировка на время принятия инвайта (гонка used_count)."""
+        result = await self.db.execute(
+            select(Invite)
+            .where(Invite.token_hash == hash_invite_token(token))
+            .with_for_update()
+        )
+        return result.scalar_one_or_none()
+
+
+def invite_to_response(invite: Invite) -> InviteResponse:
+    return InviteResponse(
+        id=invite.id,
+        email=invite.email,
+        role=invite.role,
+        group_ids=[uuid.UUID(g) for g in (invite.group_ids or [])],
+        copy_runtime_ids=invite.copy_runtime_ids,
+        copy_module_secrets=invite.copy_module_secrets,
+        max_uses=invite.max_uses,
+        used_count=invite.used_count,
+        expires_at=invite.expires_at,
+        revoked_at=invite.revoked_at,
+        created_by=invite.created_by,
+        created_at=invite.created_at,
+    )

--- a/backend/giga_agent/models/migrations/2026_07_08_1200-a1b2c3d4e5f6_add_user_role.py
+++ b/backend/giga_agent/models/migrations/2026_07_08_1200-a1b2c3d4e5f6_add_user_role.py
@@ -1,0 +1,56 @@
+"""add_user_role
+
+Роль пользователя в команде (owner/admin/member). is_superuser сохраняется и
+поддерживается синхронно с ролью для обратной совместимости существующих
+проверок.
+
+Backfill: is_superuser=true → admin; самый ранний из них → owner;
+остальные → member.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9c1b5f7e4d23
+Create Date: 2026-07-08 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "9c1b5f7e4d23"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("core_users", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "role",
+                sa.String(length=16),
+                nullable=False,
+                server_default="member",
+            )
+        )
+
+    # Существующие суперюзеры становятся админами…
+    op.execute("UPDATE core_users SET role = 'admin' WHERE is_superuser")
+    # …а самый ранний из них — владельцем инстанса.
+    op.execute(
+        """
+        UPDATE core_users SET role = 'owner'
+        WHERE id = (
+            SELECT id FROM core_users
+            WHERE is_superuser
+            ORDER BY created_at ASC, id ASC
+            LIMIT 1
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("core_users", schema=None) as batch_op:
+        batch_op.drop_column("role")

--- a/backend/giga_agent/models/migrations/2026_07_08_1300-b2c3d4e5f607_add_core_invites.py
+++ b/backend/giga_agent/models/migrations/2026_07_08_1300-b2c3d4e5f607_add_core_invites.py
@@ -1,0 +1,87 @@
+"""add_core_invites
+
+Приглашения в команду: токен хранится как SHA-256 хэш, поддерживаются
+персональные (max_uses=1) и командные (max_uses=N) ссылки.
+
+Revision ID: b2c3d4e5f607
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-08 13:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.sqltypes import Text
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f607"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_JSON = sa.JSON().with_variant(postgresql.JSONB(astext_type=Text()), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "core_invites",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("email", sa.String(), nullable=True),
+        sa.Column(
+            "role", sa.String(length=16), nullable=False, server_default="member"
+        ),
+        sa.Column("group_ids", _JSON, nullable=True),
+        sa.Column(
+            "copy_runtime_ids", sa.Boolean(), nullable=False, server_default="true"
+        ),
+        sa.Column(
+            "copy_module_secrets",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+        sa.Column("max_uses", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("used_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_by", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by"], ["core_users.id"], name="fk_core_invites_created_by"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_core_invites_id"), "core_invites", ["id"], unique=False)
+    op.create_index(
+        op.f("ix_core_invites_token_hash"),
+        "core_invites",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_core_invites_created_by"),
+        "core_invites",
+        ["created_by"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_core_invites_created_by"), table_name="core_invites")
+    op.drop_index(op.f("ix_core_invites_token_hash"), table_name="core_invites")
+    op.drop_index(op.f("ix_core_invites_id"), table_name="core_invites")
+    op.drop_table("core_invites")

--- a/backend/giga_agent/models/migrations/2026_07_08_1500-c3d4e5f60718_add_core_usage_events.py
+++ b/backend/giga_agent/models/migrations/2026_07_08_1500-c3d4e5f60718_add_core_usage_events.py
@@ -1,0 +1,59 @@
+"""add_core_usage_events
+
+Журнал вызовов LLM для страницы «Команда» (видимость потребления).
+
+Revision ID: c3d4e5f60718
+Revises: b2c3d4e5f607
+Create Date: 2026-07-08 15:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f60718"
+down_revision: Union[str, None] = "b2c3d4e5f607"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "core_usage_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("model", sa.String(length=128), nullable=True),
+        sa.Column("input_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column(
+            "output_tokens", sa.BigInteger(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_core_usage_events_user_id"),
+        "core_usage_events",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_core_usage_events_created_at"),
+        "core_usage_events",
+        ["created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_core_usage_events_created_at"), table_name="core_usage_events"
+    )
+    op.drop_index(op.f("ix_core_usage_events_user_id"), table_name="core_usage_events")
+    op.drop_table("core_usage_events")

--- a/backend/giga_agent/models/usage.py
+++ b/backend/giga_agent/models/usage.py
@@ -1,0 +1,68 @@
+"""Журнал использования LLM (лайт-версия для страницы «Команда»).
+
+Одна строка = один вызов модели. Пишется UsageTrackingMiddleware
+(fire-and-forget), агрегируется эндпоинтом /auth/team/usage.
+Не биллинг: без цен, без квот — только видимость потребления.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from pydantic import BaseModel
+from sqlalchemy import BigInteger, DateTime, String, Uuid, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from giga_agent.core.db import Base
+
+
+class UsageEvent(Base):
+    __tablename__ = "core_usage_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    input_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    output_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+
+
+class UserUsage(BaseModel):
+    user_id: uuid.UUID
+    requests: int
+    input_tokens: int
+    output_tokens: int
+    last_activity: datetime | None = None
+
+
+async def aggregate_usage(
+    session: AsyncSession, *, days: int = 30
+) -> list[UserUsage]:
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    result = await session.execute(
+        select(
+            UsageEvent.user_id,
+            func.count(UsageEvent.id),
+            func.coalesce(func.sum(UsageEvent.input_tokens), 0),
+            func.coalesce(func.sum(UsageEvent.output_tokens), 0),
+            func.max(UsageEvent.created_at),
+        )
+        .where(UsageEvent.created_at >= since)
+        .group_by(UsageEvent.user_id)
+    )
+    return [
+        UserUsage(
+            user_id=row[0],
+            requests=row[1],
+            input_tokens=row[2],
+            output_tokens=row[3],
+            last_activity=row[4],
+        )
+        for row in result.all()
+    ]

--- a/backend/giga_agent/models/users.py
+++ b/backend/giga_agent/models/users.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from cashews import cache
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
@@ -20,6 +20,30 @@ import giga_agent.models.sandbox  # noqa: F401
 import giga_agent.models.search_engine  # noqa: F401
 
 
+# ============ Roles ============
+
+# Роли команды (инстанс = одна команда):
+#   owner  — первый пользователь; всё + управление админами; не деактивируется
+#   admin  — коннекторы/LLM/секреты, приглашения, группы, управление member'ами
+#   member — пользуется расшаренными ресурсами; свои данные приватны
+ROLE_OWNER = "owner"
+ROLE_ADMIN = "admin"
+ROLE_MEMBER = "member"
+ROLES = (ROLE_OWNER, ROLE_ADMIN, ROLE_MEMBER)
+
+# Иерархия для проверок вида "минимум admin".
+_ROLE_RANK = {ROLE_MEMBER: 0, ROLE_ADMIN: 1, ROLE_OWNER: 2}
+
+
+def role_at_least(role: str | None, minimum: str) -> bool:
+    return _ROLE_RANK.get(role or ROLE_MEMBER, 0) >= _ROLE_RANK[minimum]
+
+
+def role_implies_superuser(role: str | None) -> bool:
+    """is_superuser поддерживается синхронно с role для обратной совместимости."""
+    return role in (ROLE_OWNER, ROLE_ADMIN)
+
+
 # ============ SQLAlchemy Models ============
 
 
@@ -35,6 +59,11 @@ class User(Base):
     hashed_password: Mapped[str] = mapped_column(String)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_superuser: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Источник правды по роли в команде; is_superuser держится синхронным
+    # (role in {owner, admin} => is_superuser=True) для старых проверок.
+    role: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=ROLE_MEMBER, server_default=ROLE_MEMBER
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -130,6 +159,7 @@ class UserBase(BaseModel):
     last_name: Optional[str] = None
     is_active: bool = True
     is_superuser: bool = False
+    role: str = ROLE_MEMBER
     settings: Optional[dict] = None
     secrets: Optional[dict] = None
     image_generator_id: Optional[uuid.UUID] = None
@@ -182,6 +212,7 @@ class UserShort(UserBase):
                 self.email,
                 self.is_active,
                 self.is_superuser,
+                self.role,
                 _freeze(self.settings),
                 _freeze(self.secrets),
                 _freeze(self.image_generator_id),
@@ -235,6 +266,7 @@ class AdminUserUpdate(BaseModel):
     last_name: str | None = None
     is_active: bool | None = None
     is_superuser: bool | None = None
+    role: Literal["owner", "admin", "member"] | None = None
 
 
 # ============ Repository ============
@@ -323,16 +355,25 @@ class UserRepository:
         is_active: bool = True,
         is_superuser: bool = False,
         *,
+        role: str | None = None,
         commit: bool = True,
     ) -> User:
-        """Создать нового пользователя"""
+        """Создать нового пользователя.
+
+        role — источник правды; если не передана, выводится из is_superuser
+        (True → admin). is_superuser всегда синхронизируется с ролью.
+        """
+        resolved_role = role or (ROLE_ADMIN if is_superuser else ROLE_MEMBER)
+        if resolved_role not in ROLES:
+            raise ValueError(f"Unknown role: {resolved_role}")
         user = User(
             email=email,
             hashed_password=hashed_password,
             first_name=first_name,
             last_name=last_name,
             is_active=is_active,
-            is_superuser=is_superuser,
+            is_superuser=role_implies_superuser(resolved_role),
+            role=resolved_role,
         )
         self.db.add(user)
         if commit:

--- a/backend/giga_agent/modules/auth/api.py
+++ b/backend/giga_agent/modules/auth/api.py
@@ -863,6 +863,19 @@ async def create_user(
                 detail=f"Groups not found: {missing_group_ids_str}",
             )
 
+    # role — источник правды, если задана явно; иначе легаси-вывод из
+    # is_superuser. Создать owner'а нельзя — владение только передаётся
+    # (PATCH существующего пользователя самим owner'ом).
+    explicit_role = "role" in user.model_fields_set
+    if explicit_role and user.role not in ("admin", "member"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="role must be 'admin' or 'member' (owner is transfer-only)",
+        )
+    resolved_role = (
+        user.role if explicit_role else ("admin" if user.is_superuser else "member")
+    )
+
     try:
         db_user = await user_repo.create(
             email=user.email,
@@ -870,7 +883,7 @@ async def create_user(
             first_name=user.first_name,
             last_name=user.last_name,
             is_active=user.is_active,
-            is_superuser=user.is_superuser,
+            role=resolved_role,
             commit=False,
         )
 

--- a/backend/giga_agent/modules/auth/api.py
+++ b/backend/giga_agent/modules/auth/api.py
@@ -162,6 +162,17 @@ def require_superuser(current_user: UserShort) -> None:
         )
 
 
+def require_role(current_user: UserShort, minimum: str) -> None:
+    """Проверка роли по иерархии member < admin < owner."""
+    from giga_agent.models.users import role_at_least
+
+    if not role_at_least(current_user.role, minimum):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+
 def _collect_runtime_grant_targets_from_user_model(
     user_model: User,
 ) -> set[tuple[str, uuid.UUID]]:
@@ -933,11 +944,40 @@ async def patch_user_by_id(
             "is_superuser" in body.model_fields_set
             and body.is_superuser != user.is_superuser
         )
+        or ("role" in body.model_fields_set and body.role != user.role)
     )
     if user_id == current_user.id and changes_current_user_flags:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Cannot change is_active or is_superuser for current user",
+        )
+
+    # Защита владельца: менять роль/активность owner'а может только сам owner
+    # (свои флаги и так менять нельзя — правило выше). Назначить owner'ом
+    # другого пользователя может тоже только текущий owner (передача владения).
+    from giga_agent.models.users import (
+        ROLE_OWNER,
+        role_implies_superuser,
+    )
+
+    touches_protected = (
+        "role" in body.model_fields_set
+        or "is_active" in body.model_fields_set
+        or "is_superuser" in body.model_fields_set
+    )
+    if touches_protected and user.role == ROLE_OWNER and current_user.role != ROLE_OWNER:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the owner can modify the owner account",
+        )
+    if (
+        "role" in body.model_fields_set
+        and body.role == ROLE_OWNER
+        and current_user.role != ROLE_OWNER
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the owner can transfer ownership",
         )
 
     if "email" in body.model_fields_set:
@@ -973,13 +1013,27 @@ async def patch_user_by_id(
             )
         user.is_active = body.is_active
 
-    if "is_superuser" in body.model_fields_set:
+    # role — источник правды; is_superuser поддерживается синхронно.
+    # Легаси-путь: если пришёл только is_superuser (старый фронт), выводим
+    # роль из него (True → admin, False → member; owner так не разжаловать —
+    # защищено проверками выше).
+    if "role" in body.model_fields_set:
+        if body.role is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="role must not be null",
+            )
+        user.role = body.role
+        user.is_superuser = role_implies_superuser(body.role)
+    elif "is_superuser" in body.model_fields_set:
         if body.is_superuser is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="is_superuser must not be null",
             )
         user.is_superuser = body.is_superuser
+        if user.role != ROLE_OWNER:
+            user.role = "admin" if body.is_superuser else "member"
 
     await db.commit()
     await db.refresh(user)

--- a/backend/giga_agent/modules/auth/invites_api.py
+++ b/backend/giga_agent/modules/auth/invites_api.py
@@ -116,6 +116,27 @@ async def revoke_invite(
         await db.commit()
 
 
+# ============ Команда: сводка использования ============
+
+
+@router.get("/team/usage")
+async def team_usage(
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+    days: int = 30,
+):
+    """Потребление LLM по участникам за период (для страницы «Команда»)."""
+    require_role(current_user, "admin")
+    from giga_agent.models.usage import aggregate_usage
+
+    days = max(1, min(days, 365))
+    rows = await aggregate_usage(db, days=days)
+    return {
+        "days": days,
+        "users": [row.model_dump(mode="json") for row in rows],
+    }
+
+
 # ============ Публичные: вступление по ссылке ============
 
 

--- a/backend/giga_agent/modules/auth/invites_api.py
+++ b/backend/giga_agent/modules/auth/invites_api.py
@@ -1,0 +1,247 @@
+"""API приглашений в команду.
+
+Админ-эндпоинты (/invites) — создание/список/отзыв ссылок-приглашений.
+Публичные (/join) — проверка токена и вступление в команду.
+
+Безопасность:
+- в БД хранится только SHA-256 хэш токена (утечка БД ≠ утечка инвайтов);
+- публичные ответы не различают "нет такого" / "просрочен" / "исчерпан";
+- принятие инвайта — одна транзакция с row-lock (гонка used_count).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from giga_agent.conf import get_settings
+from giga_agent.core.db import get_session
+from giga_agent.core.events import event_bus
+from giga_agent.models.group import GroupRepository
+from giga_agent.models.invite import (
+    InviteCreate,
+    InviteCreatedResponse,
+    InviteRepository,
+    InviteResponse,
+    JoinInfo,
+    JoinRequest,
+    invite_to_response,
+)
+from giga_agent.models.resource_permission import (
+    PermissionGrantItem,
+    ResourcePermissionRepository,
+)
+from giga_agent.models.users import UserRepository, UserShort
+from giga_agent.modules.auth import security
+from giga_agent.modules.auth.api import (
+    ACCESS_TOKEN_EXPIRE_MINUTES,
+    AUTH_COOKIE_NAME,
+    _collect_runtime_grant_targets_from_module_secrets,
+    _collect_runtime_grant_targets_from_user_model,
+    _get_user_model_by_id,
+    get_current_active_user,
+    get_user_repository,
+    require_role,
+)
+from giga_agent.modules.auth.events import UserCreatedEvent
+
+router = APIRouter(tags=["invites"])
+
+_INVALID_INVITE = HTTPException(
+    status_code=status.HTTP_404_NOT_FOUND,
+    detail="Приглашение недействительно или истекло",
+)
+
+
+# ============ Админ: управление приглашениями ============
+
+
+@router.post("/invites", response_model=InviteCreatedResponse)
+async def create_invite(
+    body: InviteCreate,
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    require_role(current_user, "admin")
+
+    # Проверяем существование групп до создания.
+    group_ids = list(dict.fromkeys(body.group_ids))
+    if group_ids:
+        group_repo = GroupRepository(db)
+        existing = set(await group_repo.get_existing_group_ids(group_ids))
+        missing = [str(g) for g in group_ids if g not in existing]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Groups not found: {', '.join(missing)}",
+            )
+
+    invite, token = await InviteRepository(db).create(
+        data=body, created_by=current_user.id
+    )
+    response = invite_to_response(invite)
+    return InviteCreatedResponse(
+        **response.model_dump(),
+        token=token,
+        join_path=f"/join/{token}",
+    )
+
+
+@router.get("/invites", response_model=list[InviteResponse])
+async def list_invites(
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    require_role(current_user, "admin")
+    invites = await InviteRepository(db).get_all()
+    return [invite_to_response(i) for i in invites]
+
+
+@router.delete("/invites/{invite_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_invite(
+    invite_id: uuid.UUID,
+    current_user: Annotated[UserShort, Depends(get_current_active_user)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    require_role(current_user, "admin")
+    invite = await InviteRepository(db).get_by_id(invite_id)
+    if invite is None:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    if invite.revoked_at is None:
+        invite.revoked_at = datetime.now(timezone.utc)
+        await db.commit()
+
+
+# ============ Публичные: вступление по ссылке ============
+
+
+@router.get("/join/{token}", response_model=JoinInfo)
+async def join_info(
+    token: str,
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    invite = await InviteRepository(db).get_by_token(token)
+    if invite is None:
+        return JoinInfo(valid=False)
+    usable, _ = invite.is_usable()
+    if not usable:
+        return JoinInfo(valid=False)
+    return JoinInfo(valid=True, email=invite.email, role=invite.role)
+
+
+@router.post("/join")
+async def join_team(
+    body: JoinRequest,
+    request: Request,
+    response: Response,
+    db: Annotated[AsyncSession, Depends(get_session)],
+    user_repo: Annotated[UserRepository, Depends(get_user_repository)],
+):
+    # Row-lock: конкурентное принятие одного инвайта сериализуется здесь.
+    invite = await InviteRepository(db).get_by_token_for_update(body.token)
+    if invite is None:
+        raise _INVALID_INVITE
+    usable, _ = invite.is_usable()
+    if not usable:
+        raise _INVALID_INVITE
+
+    email = str(body.email).strip().lower()
+    if invite.email and invite.email.strip().lower() != email:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Приглашение выписано на другую почту",
+        )
+    if await user_repo.exists_by_email(email):
+        raise HTTPException(status_code=400, detail="Email already registered")
+
+    try:
+        db_user = await user_repo.create(
+            email=email,
+            hashed_password=security.get_password_hash(body.password),
+            first_name=body.first_name,
+            last_name=body.last_name,
+            is_active=True,
+            role=invite.role,
+            commit=False,
+        )
+
+        # Онбординг «вошёл и работает»: runtime-ссылки создателя инвайта +
+        # read-права на них (та же механика, что в админ-создании юзера).
+        if invite.copy_runtime_ids:
+            creator = await _get_user_model_by_id(db, invite.created_by)
+            db_user.llm_id = creator.llm_id
+            db_user.fast_llm_id = creator.fast_llm_id
+            db_user.embedding_id = creator.embedding_id
+            db_user.image_generator_id = creator.image_generator_id
+            db_user.search_engine_id = creator.search_engine_id
+            db_user.sandbox_provider_id = creator.sandbox_provider_id
+
+            grant_targets = _collect_runtime_grant_targets_from_user_model(creator)
+            if invite.copy_module_secrets:
+                db_user.secrets = dict(creator.secrets or {})
+                grant_targets.update(
+                    await _collect_runtime_grant_targets_from_module_secrets(
+                        request=request,
+                        secrets=db_user.secrets,
+                    )
+                )
+            if grant_targets:
+                grants = [
+                    PermissionGrantItem(
+                        resource_type=resource_type,
+                        resource_id=resource_id,
+                        owner_type="user",
+                        owner_id=db_user.id,
+                        permission="read",
+                    )
+                    for resource_type, resource_id in sorted(
+                        grant_targets, key=lambda item: (item[0], str(item[1]))
+                    )
+                ]
+                await ResourcePermissionRepository(db).grant_permissions(
+                    items=grants, no_commit=True
+                )
+
+        group_repo = GroupRepository(db)
+        for raw_gid in invite.group_ids or []:
+            await group_repo.add_users(
+                uuid.UUID(raw_gid), [db_user.id], commit=False
+            )
+
+        invite.used_count += 1
+        await db.commit()
+        await db.refresh(db_user)
+    except HTTPException:
+        await db.rollback()
+        raise
+    except Exception:
+        await db.rollback()
+        raise
+
+    await event_bus.publish(UserCreatedEvent(user_id=db_user.id, email=db_user.email))
+
+    # Сразу логиним нового участника (как /token).
+    access_token_expires = (
+        timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+        if ACCESS_TOKEN_EXPIRE_MINUTES
+        else None
+    )
+    access_token = security.create_access_token(
+        data={"sub": db_user.email, "user_id": str(db_user.id)},
+        expires_delta=access_token_expires,
+    )
+    cookie_domain = get_settings().giga_agent_public_base_domain
+    response.set_cookie(
+        key=AUTH_COOKIE_NAME,
+        value=access_token,
+        httponly=True,
+        samesite="lax",
+        secure=request.url.scheme == "https",
+        path="/",
+        domain=cookie_domain,
+    )
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/backend/giga_agent/modules/auth/module.py
+++ b/backend/giga_agent/modules/auth/module.py
@@ -19,7 +19,18 @@ class AuthModule(BaseModule):
 
     def get_api_router(self, **kwargs: Any) -> APIRouter:
         _ = kwargs
-        return api.router
+        from giga_agent.modules.auth import invites_api
+
+        combined = APIRouter()
+        combined.include_router(api.router)
+        combined.include_router(invites_api.router)
+        return combined
+
+    def get_models(self, **kwargs: Any) -> list[type]:
+        _ = kwargs
+        from giga_agent.models.invite import Invite
+
+        return [Invite]
 
     async def on_startup(self, session: AsyncSession, **kwargs: Any):
         _ = kwargs

--- a/backend/giga_agent/modules/auth/module.py
+++ b/backend/giga_agent/modules/auth/module.py
@@ -42,6 +42,7 @@ class AuthModule(BaseModule):
                 hashed_password=hashed_password,
                 is_active=True,
                 is_superuser=True,
+                role="owner",  # первый пользователь инстанса — владелец команды
                 first_name="Admin",
             )
 

--- a/backend/giga_agent/modules/auth/module.py
+++ b/backend/giga_agent/modules/auth/module.py
@@ -29,8 +29,9 @@ class AuthModule(BaseModule):
     def get_models(self, **kwargs: Any) -> list[type]:
         _ = kwargs
         from giga_agent.models.invite import Invite
+        from giga_agent.models.usage import UsageEvent
 
-        return [Invite]
+        return [Invite, UsageEvent]
 
     async def on_startup(self, session: AsyncSession, **kwargs: Any):
         _ = kwargs

--- a/backend/giga_agent/modules/auth/module.py
+++ b/backend/giga_agent/modules/auth/module.py
@@ -64,3 +64,10 @@ class AuthModule(BaseModule):
             logger.info(f"Admin user created: {admin_email}:{admin_password}")
         else:
             logger.info("Users exist. Skipping admin creation.")
+
+        # Команда инстанса: системная группа All Members (создание + бэкфилл)
+        # и авто-членство новых пользователей по UserCreatedEvent.
+        from giga_agent.core.team import ensure_all_members_group, ensure_subscribed
+
+        await ensure_all_members_group(session)
+        await ensure_subscribed()

--- a/backend/giga_agent/routes/groups.py
+++ b/backend/giga_agent/routes/groups.py
@@ -158,6 +158,13 @@ async def delete_group(
 ):
     require_superuser(current_user)
     group = await _get_group_or_404(group_id, group_repo)
+    from giga_agent.core.team import is_system_group
+
+    if is_system_group(group):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Системную группу All Members нельзя удалить",
+        )
     await group_repo.delete(group)
 
 
@@ -199,7 +206,14 @@ async def remove_group_user(
     group_repo: Annotated[GroupRepository, Depends(get_group_repository)],
 ):
     require_superuser(current_user)
-    await _get_group_or_404(group_id, group_repo)
+    group = await _get_group_or_404(group_id, group_repo)
+    from giga_agent.core.team import is_system_group
+
+    if is_system_group(group):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Из системной группы All Members нельзя исключать участников",
+        )
     removed = await group_repo.remove_user(group_id, user_id)
     if not removed:
         raise HTTPException(

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -26,6 +26,7 @@ import { Toaster } from "@/components/ui/sonner.tsx";
 import MemoriesPage from "@/components/memories/MemoriesPage.tsx";
 import ProjectPage from "@/components/projects/ProjectPage.tsx";
 import LoginPage from "@/components/auth/LoginPage.tsx";
+import JoinPage from "@/components/auth/JoinPage.tsx";
 import ProtectedRoute from "@/components/auth/ProtectedRoute.tsx";
 import SettingsPage from "@/components/settings-page";
 import AdminPanelPage from "@/components/admin-panel";
@@ -165,6 +166,7 @@ const AppRoutes: React.FC<{
         />
         <Route path="/admin-panel/users" element={<AdminPanelPage />} />
         <Route path="/admin-panel/groups" element={<AdminPanelPage />} />
+        <Route path="/admin-panel/invites" element={<AdminPanelPage />} />
       </Routes>
     );
   },
@@ -207,6 +209,7 @@ const App: React.FC = () => {
                       <SkillsProvider>
                         <Routes>
                           <Route path="/login" element={<LoginPage />} />
+                          <Route path="/join/:token" element={<JoinPage />} />
                           <Route
                             path="/*"
                             element={

--- a/front/src/components/admin-panel/index.tsx
+++ b/front/src/components/admin-panel/index.tsx
@@ -7,12 +7,16 @@ import { Button } from "@/components/ui/button";
 import { useAuth } from "@/components/providers/auth.tsx";
 import AdminUsersTab from "./users";
 import AdminGroupsTab from "./groups";
+import AdminInvitesTab from "./invites";
 
-type AdminTab = "users" | "groups";
+type AdminTab = "users" | "groups" | "invites";
 
 const resolveActiveTab = (pathname: string): AdminTab => {
   if (pathname.includes("/admin-panel/groups")) {
     return "groups";
+  }
+  if (pathname.includes("/admin-panel/invites")) {
+    return "invites";
   }
   return "users";
 };
@@ -31,6 +35,7 @@ const AdminPanelPage: React.FC = () => {
   const tabs: { id: AdminTab; label: string; url: string }[] = [
     { id: "users", label: "Пользователи", url: "/admin-panel/users" },
     { id: "groups", label: "Группы", url: "/admin-panel/groups" },
+    { id: "invites", label: "Приглашения", url: "/admin-panel/invites" },
   ];
 
   return (
@@ -54,7 +59,13 @@ const AdminPanelPage: React.FC = () => {
         </div>
 
         <div className="flex-1 overflow-auto p-6 flex flex-col">
-          {activeTab === "users" ? <AdminUsersTab /> : <AdminGroupsTab />}
+          {activeTab === "users" ? (
+            <AdminUsersTab />
+          ) : activeTab === "groups" ? (
+            <AdminGroupsTab />
+          ) : (
+            <AdminInvitesTab />
+          )}
         </div>
       </div>
     </div>

--- a/front/src/components/admin-panel/invites.tsx
+++ b/front/src/components/admin-panel/invites.tsx
@@ -1,0 +1,358 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Copy, Link2, Loader2, Plus, XCircle } from "lucide-react";
+import { toast } from "sonner";
+
+import { API_AGENT_PREFIX } from "@/config.ts";
+import { apiClient } from "@/lib/api-client";
+import { useConfirm } from "@/components/providers/confirm.tsx";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type Invite = {
+  id: string;
+  email: string | null;
+  role: string;
+  max_uses: number;
+  used_count: number;
+  expires_at: string;
+  revoked_at: string | null;
+  created_at: string;
+  copy_runtime_ids: boolean;
+};
+
+type InviteCreated = Invite & { token: string; join_path: string };
+
+type FormState = {
+  email: string;
+  role: "member" | "admin";
+  max_uses: number;
+  expires_in_days: number;
+  copy_runtime_ids: boolean;
+};
+
+const initialForm: FormState = {
+  email: "",
+  role: "member",
+  max_uses: 1,
+  expires_in_days: 7,
+  copy_runtime_ids: true,
+};
+
+const inviteStatus = (invite: Invite): { label: string; variant: "default" | "outline" | "destructive" | "secondary" } => {
+  if (invite.revoked_at) return { label: "Отозвано", variant: "destructive" };
+  if (new Date(invite.expires_at) <= new Date())
+    return { label: "Истекло", variant: "secondary" };
+  if (invite.used_count >= invite.max_uses)
+    return { label: "Использовано", variant: "secondary" };
+  return { label: "Активно", variant: "default" };
+};
+
+const AdminInvitesTab: React.FC = () => {
+  const confirm = useConfirm();
+  const [invites, setInvites] = useState<Invite[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [form, setForm] = useState<FormState>(initialForm);
+  const [creating, setCreating] = useState(false);
+  // Ссылка показывается один раз после создания.
+  const [createdLink, setCreatedLink] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await apiClient.get<Invite[]>(
+        `${API_AGENT_PREFIX}/auth/invites`,
+      );
+      setInvites(data);
+    } catch {
+      toast.error("Не удалось загрузить приглашения");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    try {
+      const body: Record<string, unknown> = {
+        role: form.role,
+        max_uses: form.max_uses,
+        expires_in_days: form.expires_in_days,
+        copy_runtime_ids: form.copy_runtime_ids,
+      };
+      if (form.email.trim()) body.email = form.email.trim();
+      const created = await apiClient.post<InviteCreated>(
+        `${API_AGENT_PREFIX}/auth/invites`,
+        body,
+      );
+      const url = `${window.location.origin}/join/${created.token}`;
+      setCreatedLink(url);
+      setForm(initialForm);
+      await load();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Не удалось создать приглашение",
+      );
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleRevoke = async (invite: Invite) => {
+    const ok = await confirm({
+      title: "Отозвать приглашение?",
+      description: "Ссылка перестанет работать. Это действие необратимо.",
+    });
+    if (!ok) return;
+    try {
+      await apiClient.delete(`${API_AGENT_PREFIX}/auth/invites/${invite.id}`);
+      toast.success("Приглашение отозвано");
+      await load();
+    } catch {
+      toast.error("Не удалось отозвать приглашение");
+    }
+  };
+
+  const copyLink = async (url: string) => {
+    await navigator.clipboard.writeText(url);
+    toast.success("Ссылка скопирована");
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Ссылки-приглашения в команду. Токен показывается один раз при
+          создании — скопируйте и отправьте приглашённому.
+        </p>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="h-4 w-4 mr-1" /> Пригласить
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : invites.length === 0 ? (
+        <div className="text-sm text-muted-foreground py-8 text-center">
+          Приглашений пока нет
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Статус</TableHead>
+              <TableHead>Роль</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Использований</TableHead>
+              <TableHead>Истекает</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {invites.map((invite) => {
+              const st = inviteStatus(invite);
+              return (
+                <TableRow key={invite.id}>
+                  <TableCell>
+                    <Badge variant={st.variant}>{st.label}</Badge>
+                  </TableCell>
+                  <TableCell>{invite.role}</TableCell>
+                  <TableCell>{invite.email ?? "—"}</TableCell>
+                  <TableCell>
+                    {invite.used_count}/{invite.max_uses}
+                  </TableCell>
+                  <TableCell>
+                    {new Date(invite.expires_at).toLocaleDateString("ru-RU")}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {st.label === "Активно" && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        title="Отозвать"
+                        onClick={() => void handleRevoke(invite)}
+                      >
+                        <XCircle className="h-4 w-4 text-destructive" />
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Диалог создания */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Пригласить в команду</DialogTitle>
+            <DialogDescription>
+              Будет создана ссылка-приглашение. Отправьте её любым удобным
+              способом.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Роль</Label>
+              <Select
+                value={form.role}
+                onValueChange={(v) =>
+                  setForm((f) => ({ ...f, role: v as FormState["role"] }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="member">Участник (member)</SelectItem>
+                  <SelectItem value="admin">Администратор (admin)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="invite-email">
+                Email (необязательно — ограничить конкретной почтой)
+              </Label>
+              <Input
+                id="invite-email"
+                type="email"
+                placeholder="user@example.com"
+                value={form.email}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, email: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="invite-uses">Максимум использований</Label>
+                <Input
+                  id="invite-uses"
+                  type="number"
+                  min={1}
+                  max={1000}
+                  value={form.max_uses}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      max_uses: Math.max(1, Number(e.target.value) || 1),
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="invite-days">Срок действия (дней)</Label>
+                <Input
+                  id="invite-days"
+                  type="number"
+                  min={1}
+                  max={90}
+                  value={form.expires_in_days}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      expires_in_days: Math.max(1, Number(e.target.value) || 7),
+                    }))
+                  }
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="invite-copy" className="cursor-pointer">
+                Скопировать мои настройки LLM приглашённому
+              </Label>
+              <Switch
+                id="invite-copy"
+                checked={form.copy_runtime_ids}
+                onCheckedChange={(checked) =>
+                  setForm((f) => ({ ...f, copy_runtime_ids: checked }))
+                }
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setCreateOpen(false)}>
+                Отмена
+              </Button>
+              <Button onClick={() => void handleCreate()} disabled={creating}>
+                {creating ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  "Создать ссылку"
+                )}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Диалог «ссылка создана» — показывается один раз */}
+      <Dialog
+        open={createdLink !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCreatedLink(null);
+            setCreateOpen(false);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Link2 className="h-5 w-5" /> Ссылка-приглашение готова
+            </DialogTitle>
+            <DialogDescription>
+              Скопируйте сейчас — повторно ссылка не показывается (в системе
+              хранится только её отпечаток).
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-center gap-2">
+            <Input readOnly value={createdLink ?? ""} className="font-mono" />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => createdLink && void copyLink(createdLink)}
+              title="Скопировать"
+            >
+              <Copy className="h-4 w-4" />
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default AdminInvitesTab;

--- a/front/src/components/admin-panel/types.ts
+++ b/front/src/components/admin-panel/types.ts
@@ -5,6 +5,7 @@ export type AdminUser = {
   last_name: string | null;
   is_active: boolean;
   is_superuser: boolean;
+  role?: "owner" | "admin" | "member";
   settings: Record<string, unknown> | null;
   secrets: Record<string, unknown> | null;
   llm_id: string | null;

--- a/front/src/components/admin-panel/users.tsx
+++ b/front/src/components/admin-panel/users.tsx
@@ -101,9 +101,32 @@ const AdminUsersTab: React.FC = () => {
     }
   }, []);
 
+  // Потребление LLM за 30 дней (страница «Команда»): user_id → агрегат.
+  const [usageByUser, setUsageByUser] = useState<
+    Record<string, { requests: number; input_tokens: number; output_tokens: number }>
+  >({});
+
+  const fetchUsage = useCallback(async () => {
+    try {
+      const data = await apiClient.get<{
+        users: {
+          user_id: string;
+          requests: number;
+          input_tokens: number;
+          output_tokens: number;
+        }[];
+      }>(`${API_AGENT_PREFIX}/auth/team/usage?days=30`);
+      setUsageByUser(
+        Object.fromEntries(data.users.map((u) => [u.user_id, u])),
+      );
+    } catch {
+      // Не критично для списка пользователей.
+    }
+  }, []);
+
   useEffect(() => {
-    void Promise.all([fetchUsers(), fetchGroups()]);
-  }, [fetchUsers, fetchGroups]);
+    void Promise.all([fetchUsers(), fetchGroups(), fetchUsage()]);
+  }, [fetchUsers, fetchGroups, fetchUsage]);
 
   const groupOptions = useMemo(
     () =>
@@ -282,6 +305,7 @@ const AdminUsersTab: React.FC = () => {
                 <TableHead>Имя</TableHead>
                 <TableHead>Роль</TableHead>
                 <TableHead>Статус</TableHead>
+                <TableHead>Токены (30д)</TableHead>
                 <TableHead className="text-right">Действия</TableHead>
               </TableRow>
             </TableHeader>
@@ -302,13 +326,35 @@ const AdminUsersTab: React.FC = () => {
                     <TableCell>{fullName || "-"}</TableCell>
                     <TableCell>
                       <Badge variant={u.is_superuser ? "default" : "outline"}>
-                        {u.is_superuser ? "Admin" : "User"}
+                        {u.role ?? (u.is_superuser ? "admin" : "member")}
                       </Badge>
                     </TableCell>
                     <TableCell>
                       <Badge variant={u.is_active ? "default" : "secondary"}>
                         {u.is_active ? "Активен" : "Неактивен"}
                       </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {(() => {
+                        const usage = usageByUser[u.id];
+                        if (!usage) {
+                          return (
+                            <span className="text-muted-foreground">—</span>
+                          );
+                        }
+                        const total =
+                          usage.input_tokens + usage.output_tokens;
+                        return (
+                          <span
+                            title={`Запросов: ${usage.requests} · вход: ${usage.input_tokens.toLocaleString("ru-RU")} · выход: ${usage.output_tokens.toLocaleString("ru-RU")}`}
+                          >
+                            {total.toLocaleString("ru-RU")}
+                            <span className="text-xs text-muted-foreground ml-1">
+                              ({usage.requests} запр.)
+                            </span>
+                          </span>
+                        );
+                      })()}
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-1">

--- a/front/src/components/admin-panel/users.tsx
+++ b/front/src/components/admin-panel/users.tsx
@@ -19,6 +19,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchableMultiSelect } from "@/components/ui/searchable-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
   Table,
@@ -37,7 +44,7 @@ type UserFormState = {
   first_name: string;
   last_name: string;
   is_active: boolean;
-  is_superuser: boolean;
+  role: "owner" | "admin" | "member";
   group_ids: string[];
   copy_owner_runtime_ids: boolean;
   copy_owner_module_secrets: boolean;
@@ -49,7 +56,7 @@ const initialFormState: UserFormState = {
   first_name: "",
   last_name: "",
   is_active: true,
-  is_superuser: false,
+  role: "member",
   group_ids: [],
   copy_owner_runtime_ids: false,
   copy_owner_module_secrets: false,
@@ -165,7 +172,7 @@ const AdminUsersTab: React.FC = () => {
         first_name: form.first_name || null,
         last_name: form.last_name || null,
         is_active: form.is_active,
-        is_superuser: form.is_superuser,
+        role: form.role,
         group_ids: form.group_ids,
         copy_owner_runtime_ids: form.copy_owner_runtime_ids,
         copy_owner_module_secrets: form.copy_owner_module_secrets,
@@ -212,7 +219,7 @@ const AdminUsersTab: React.FC = () => {
       first_name: user.first_name ?? "",
       last_name: user.last_name ?? "",
       is_active: user.is_active,
-      is_superuser: user.is_superuser,
+      role: user.role ?? (user.is_superuser ? "admin" : "member"),
       group_ids: [],
       copy_owner_runtime_ids: false,
       copy_owner_module_secrets: false,
@@ -229,7 +236,7 @@ const AdminUsersTab: React.FC = () => {
       first_name: editForm.first_name || null,
       last_name: editForm.last_name || null,
       is_active: editForm.is_active,
-      is_superuser: editForm.is_superuser,
+      role: editForm.role,
     };
 
     if (isChangePassword) {
@@ -477,14 +484,22 @@ const AdminUsersTab: React.FC = () => {
                 Активен
               </label>
               <label className="flex items-center gap-2 text-sm">
-                <Switch
-                  checked={form.is_superuser}
-                  onCheckedChange={(checked) =>
-                    setForm({ ...form, is_superuser: checked })
+                Роль
+                <Select
+                  value={form.role}
+                  onValueChange={(v) =>
+                    setForm({ ...form, role: v as UserFormState["role"] })
                   }
                   disabled={creating}
-                />
-                Суперпользователь
+                >
+                  <SelectTrigger className="w-[180px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="member">Участник (member)</SelectItem>
+                    <SelectItem value="admin">Администратор (admin)</SelectItem>
+                  </SelectContent>
+                </Select>
               </label>
             </div>
 
@@ -667,14 +682,34 @@ const AdminUsersTab: React.FC = () => {
                 Активен
               </label>
               <label className="flex items-center gap-2 text-sm">
-                <Switch
-                  checked={editForm.is_superuser}
-                  onCheckedChange={(checked) =>
-                    setEditForm({ ...editForm, is_superuser: checked })
+                Роль
+                <Select
+                  value={editForm.role}
+                  onValueChange={(v) =>
+                    setEditForm({
+                      ...editForm,
+                      role: v as UserFormState["role"],
+                    })
                   }
-                  disabled={updating || editingUserId === currentUser?.id}
-                />
-                Суперпользователь
+                  disabled={
+                    updating ||
+                    editingUserId === currentUser?.id ||
+                    // Роль owner'а меняется только передачей владения —
+                    // здесь показываем её как есть, без редактирования.
+                    editForm.role === "owner"
+                  }
+                >
+                  <SelectTrigger className="w-[180px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {editForm.role === "owner" && (
+                      <SelectItem value="owner">Владелец (owner)</SelectItem>
+                    )}
+                    <SelectItem value="member">Участник (member)</SelectItem>
+                    <SelectItem value="admin">Администратор (admin)</SelectItem>
+                  </SelectContent>
+                </Select>
               </label>
             </div>
 

--- a/front/src/components/auth/JoinPage.tsx
+++ b/front/src/components/auth/JoinPage.tsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useState, FormEvent } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useAuth } from "@/components/providers/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, Loader2 } from "lucide-react";
+import LogoWhiteImage from "@/assets/gigachain_logo.svg";
+import { API_AGENT_PREFIX } from "@/config.ts";
+
+type JoinInfo = {
+  valid: boolean;
+  email: string | null;
+  role: string | null;
+};
+
+/**
+ * Публичная страница вступления в команду по ссылке-приглашению /join/<token>.
+ * Проверяет токен, собирает имя/почту/пароль, создаёт аккаунт и сразу логинит.
+ */
+const JoinPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+  const { token } = useParams<{ token: string }>();
+
+  const [info, setInfo] = useState<JoinInfo | null>(null);
+  const [loadingInfo, setLoadingInfo] = useState(true);
+
+  const [email, setEmail] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [password, setPassword] = useState("");
+  const [password2, setPassword2] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await fetch(
+          `${API_AGENT_PREFIX}/auth/join/${encodeURIComponent(token ?? "")}`,
+        );
+        const data = resp.ok ? await resp.json() : { valid: false };
+        if (!cancelled) {
+          setInfo(data);
+          if (data?.email) setEmail(data.email);
+        }
+      } catch {
+        if (!cancelled) setInfo({ valid: false, email: null, role: null });
+      } finally {
+        if (!cancelled) setLoadingInfo(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (password !== password2) {
+      setError("Пароли не совпадают");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const resp = await fetch(`${API_AGENT_PREFIX}/auth/join`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token,
+          email,
+          password,
+          first_name: firstName || null,
+        }),
+      });
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        throw new Error(
+          err.message || err.detail || "Не удалось принять приглашение",
+        );
+      }
+      // Аккаунт создан — входим обычным логином (заполняет auth-контекст).
+      await login(email, password);
+      navigate("/", { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Ошибка вступления");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const emailLocked = Boolean(info?.email);
+
+  return (
+    <div className="min-h-screen w-full flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">
+            Вступление в{" "}
+            <img
+              className="w-10 h-10 inline-block"
+              src={LogoWhiteImage}
+              alt="GigaAgent Logo"
+            />{" "}
+            GigaAgent
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loadingInfo ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : !info?.valid ? (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                Приглашение недействительно или истекло. Запросите новую ссылку
+                у администратора.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <p className="text-sm text-muted-foreground text-center">
+                Вас пригласили в команду
+                {info.role === "admin" ? " администратором" : ""}. Создайте
+                аккаунт, чтобы продолжить.
+              </p>
+
+              {error && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="join-name">Имя</Label>
+                <Input
+                  id="join-name"
+                  placeholder="Как к вам обращаться"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  autoComplete="given-name"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="join-email">Email</Label>
+                <Input
+                  id="join-email"
+                  type="email"
+                  placeholder="user@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  autoComplete="email"
+                  disabled={isSubmitting || emailLocked}
+                />
+                {emailLocked && (
+                  <p className="text-xs text-muted-foreground">
+                    Приглашение выписано на эту почту
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="join-password">Пароль</Label>
+                <PasswordInput
+                  id="join-password"
+                  placeholder="Минимум 8 символов"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="join-password2">Пароль ещё раз</Label>
+                <PasswordInput
+                  id="join-password2"
+                  placeholder="••••••••"
+                  value={password2}
+                  onChange={(e) => setPassword2(e.target.value)}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <Button type="submit" className="w-full" disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Создаём аккаунт…
+                  </>
+                ) : (
+                  "Присоединиться"
+                )}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default JoinPage;

--- a/front/src/components/providers/api.tsx
+++ b/front/src/components/providers/api.tsx
@@ -23,6 +23,13 @@ export const ApiProvider: React.FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     // Обработка 401 ошибки
     apiClient.setUnauthorizedHandler(() => {
+      // На публичных страницах (вступление по инвайту, логин) фоновые 401 от
+      // провайдеров — норма: пользователь ещё не аутентифицирован. Не дёргаем
+      // toast и не уводим со страницы.
+      const publicPath =
+        window.location.pathname.startsWith("/join/") ||
+        window.location.pathname.startsWith("/login");
+      if (publicPath) return;
       toast.error("Сессия истекла", {
         description: "Пожалуйста, войдите в систему снова",
         richColors: true,

--- a/front/src/components/settings-page/forms/resource-permissions.tsx
+++ b/front/src/components/settings-page/forms/resource-permissions.tsx
@@ -21,6 +21,8 @@ type GroupOption = {
   id: string;
   name: string;
   description: string | null;
+  // Маркер системной группы (data.system === "all_members" → вся команда).
+  data?: { system?: string } | null;
 };
 
 interface ResourcePermissionsProps {
@@ -109,6 +111,14 @@ const ResourcePermissions: React.FC<ResourcePermissionsProps> = ({
     [groups],
   );
 
+  const allMembersId = useMemo(
+    () => groups.find((g) => g.data?.system === "all_members")?.id ?? null,
+    [groups],
+  );
+  const sharedWithTeam = Boolean(
+    allMembersId && value.read_group_ids.includes(allMembersId),
+  );
+
   if (!canManage) {
     return null;
   }
@@ -120,8 +130,36 @@ const ResourcePermissions: React.FC<ResourcePermissionsProps> = ({
       ? `${resourceType}:${resourceId.slice(0, 8)}`
       : `${resourceType}:new`;
 
+  const toggleTeamShare = (checked: boolean) => {
+    if (!allMembersId) return;
+    const rest = value.read_group_ids.filter((id) => id !== allMembersId);
+    onChange({
+      ...value,
+      read_group_ids: checked ? [...rest, allMembersId] : rest,
+    });
+  };
+
   return (
     <div className="space-y-3">
+      {/* Быстрый шаринг на всю команду — виден без разворачивания секции */}
+      {allMembersId && (
+        <div className="flex items-center justify-between rounded-md border border-border p-3">
+          <div>
+            <Label htmlFor="permission-team-share" className="cursor-pointer">
+              Доступно команде
+            </Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Все участники получат доступ на чтение
+            </p>
+          </div>
+          <Switch
+            id="permission-team-share"
+            checked={sharedWithTeam}
+            onCheckedChange={toggleTeamShare}
+            disabled={isDisabled}
+          />
+        </div>
+      )}
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}


### PR DESCRIPTION
> **Draft / RFC** — открыто для обсуждения. Готов разбить на части и доработать под требования проекта.

## Мотивация

Сейчас онбординг участника в self-hosted GigaAgent — ручной: админ создаёт пользователя с паролем, а доступы к LLM/коннекторам раздаются точечно. Для командного использования («настроил один раз — команда работает», как в Claude Enterprise) не хватает приглашений, ролей и шаринга по умолчанию.

## Что в PR

Дизайн-принцип: **инстанс = одна команда**. Никакой мульти-тенантности — всё строится поверх существующих `Group` и `ResourcePermission`, схема которых не менялась.

### 1. Роли (`owner` / `admin` / `member`)
- `User.role` — источник правды; `is_superuser` сохранён и поддерживается синхронно → существующие проверки работают без изменений.
- Миграция с бэкфиллом: superuser'ы → admin, самый ранний → owner.
- Защита owner'а: менять/передавать владение может только owner; создать owner'а нельзя (только передача).

### 2. Приглашения по ссылке (`core_invites`)
- В БД хранится только SHA-256 хэш токена; персональные (max_uses=1) и командные (max_uses=N) ссылки; TTL; отзыв; опциональная привязка к email.
- Публичная страница `/join/<token>`: форма → аккаунт → авто-вход.
- Онбординг «вошёл и работает»: опциональное копирование runtime-ссылок создателя + read-права (та же механика, что в админ-создании юзера).
- Единый 404 без оракула (нет/просрочен/исчерпан неразличимы), row-lock против гонки `used_count`.

### 3. Системная группа All Members
- Создаётся на старте, членство автоматическое (бэкфилл + UserCreatedEvent), удаление/исключение запрещены.
- **Тумблер «Доступно команде»** в компоненте `ResourcePermissions` — один клик = read-право группы. Автоматически появился на всех карточках (LLM, коннекторы, эмбеддинги, генераторы, песочницы, RAG-коллекции).

### 4. Учёт использования
- `core_usage_events` + `UsageTrackingMiddleware` (fire-and-forget, ошибки учёта не влияют на поток).
- `GET /auth/team/usage?days=N` + колонка «Токены (30д)» в админке.

### 5. UI
- Админка: вкладка «Приглашения» (создание/статусы/отзыв, ссылка показывается один раз), селект роли в формах пользователя.

## Тестирование (всё E2E на живом инстансе)
- Вступление по ссылке через браузер: форма → авто-логин → приложение.
- Повтор исчерпанной ссылки → 404; member не допускается в админку.
- Шаринг: member **без** скопированных настроек видит расшаренный LLM.
- RAG: до шаринга — 403 и пустой список; после — видит коллекцию, семантический поиск по чужому документу работает, запись отбивается 403 (read ≠ write). Достигнуто нулём нового кода — только существующий ACL.
- Usage: вызов → журнал → агрегат → колонка.

## Открытые вопросы
1. Разбивка: роли+инвайты отдельно от usage — если так удобнее ревьюить.
2. Судьба `is_superuser`: держим синхронным или планово выпиливаем.
3. Передача владения — сейчас только через PATCH role owner'ом; нужен ли отдельный UX.
4. Квоты per-user поверх `core_rate_limits` — вне скоупа, но напрашивается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)