### PR TITLE
fix: return 409 when an embedding is used by RAG

### DIFF
--- a/backend/giga_agent/models/rag.py
+++ b/backend/giga_agent/models/rag.py
@@ -150,6 +150,14 @@ class RagCollectionsRepository(ACLResourceRepositoryMixin[RagCollection]):
         )
         return list(result.scalars().all())
 
+    async def exists_for_embedding(self, embedding_id: uuid.UUID) -> bool:
+        collection_id = await self.db.scalar(
+            select(RagCollection.id)
+            .where(RagCollection.embedding_id == embedding_id)
+            .limit(1)
+        )
+        return collection_id is not None
+
     async def list_readable_for_user(
         self,
         *,

--- a/backend/giga_agent/routes/embeddings.py
+++ b/backend/giga_agent/routes/embeddings.py
@@ -27,6 +27,7 @@ from giga_agent.models import (
     EmbeddingResponse,
 )
 from giga_agent.models.connector import Connector, ConnectorRepository
+from giga_agent.models.rag import RagCollectionsRepository
 from giga_agent.models.resource_permission import ResourcePermissionRepository
 from giga_agent.models.users import UserRepository, UserShort
 from giga_agent.modules.auth.api import get_current_active_user, require_superuser
@@ -558,6 +559,14 @@ async def delete_embedding(
         user_id=current_user.id,
         embedding_repo=embedding_repo,
     )
+    if await RagCollectionsRepository(db).exists_for_embedding(embedding.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Embedding is used by one or more RAG collections. "
+                "Delete those collections before deleting the embedding."
+            ),
+        )
     old_embedding_id = user.embedding_id if user.embedding_id == embedding.id else None
     await embedding_repo.delete(embedding)
     was_cleared = await clear_user_current_link_if_matches(

--- a/backend/tests/models/test_rag_collections_repository.py
+++ b/backend/tests/models/test_rag_collections_repository.py
@@ -79,3 +79,36 @@ class RagCollectionsRepositoryTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(deleted)
         self.assertEqual(acl, [])
+
+    async def test_exists_for_embedding_tracks_collection_dependency(self) -> None:
+        owner = await self._create_user("rag-owner-embedding-check@example.com")
+
+        async with self.session_factory() as session:
+            connector = await ConnectorRepository(session).create(
+                owner_id=owner.id,
+                connector_type="openai",
+                settings={"api_key": "sk-test"},
+                is_active=True,
+            )
+            embedding = await EmbeddingRepository(session).create(
+                owner_id=owner.id,
+                embedding_type="openai",
+                connector_id=connector.id,
+                model_id="text-embedding-3-small",
+                vector_size=1536,
+                settings={},
+                is_active=True,
+            )
+            repo = RagCollectionsRepository(session)
+
+            self.assertFalse(await repo.exists_for_embedding(embedding.id))
+
+            collection = await repo.create(
+                owner_id=owner.id,
+                name="docs",
+                embedding_id=embedding.id,
+            )
+            self.assertTrue(await repo.exists_for_embedding(embedding.id))
+
+            await repo.delete(owner_id=owner.id, collection_id=collection.id)
+            self.assertFalse(await repo.exists_for_embedding(embedding.id))

--- a/backend/tests/routes/test_embeddings_router.py
+++ b/backend/tests/routes/test_embeddings_router.py
@@ -17,7 +17,9 @@ class EmbeddingsRouterTests(unittest.TestCase):
         self.user = types.SimpleNamespace(
             id=uuid.uuid4(), is_active=True, is_superuser=True
         )
-        self.db = types.SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
+        self.db = types.SimpleNamespace(
+            commit=AsyncMock(), refresh=AsyncMock(), scalar=AsyncMock(return_value=None)
+        )
         self.app = FastAPI()
         self.app.include_router(router)
 
@@ -802,3 +804,46 @@ class EmbeddingsRouterTests(unittest.TestCase):
         self.assertEqual(event.user_id, self.user.id)
         self.assertEqual(event.old_embedding_id, embedding_id)
         self.assertIsNone(event.new_embedding_id)
+
+    def test_delete_embedding_used_by_rag_collection_returns_conflict(self):
+        embedding_id = uuid.uuid4()
+        existing = self._embedding_obj(embedding_id=embedding_id)
+        user_model = types.SimpleNamespace(embedding_id=embedding_id)
+        self.db.scalar.return_value = uuid.uuid4()
+
+        with (
+            patch(
+                "giga_agent.routes.embeddings.get_user_model",
+                AsyncMock(return_value=user_model),
+            ),
+            patch(
+                "giga_agent.routes.embeddings._get_embedding_with_write_check",
+                AsyncMock(return_value=existing),
+            ),
+            patch(
+                "giga_agent.routes.embeddings.EmbeddingRepository.delete",
+                AsyncMock(return_value=None),
+            ) as mocked_delete,
+            patch(
+                "giga_agent.routes.embeddings.clear_user_current_link_if_matches",
+                AsyncMock(return_value=True),
+            ) as mocked_clear_current,
+            patch(
+                "giga_agent.routes.embeddings.event_bus.publish",
+                AsyncMock(return_value=None),
+            ) as mocked_publish,
+        ):
+            response = self.client.delete(f"/embeddings/{embedding_id}")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.json()["detail"],
+            (
+                "Embedding is used by one or more RAG collections. "
+                "Delete those collections before deleting the embedding."
+            ),
+        )
+        mocked_delete.assert_not_awaited()
+        mocked_clear_current.assert_not_awaited()
+        mocked_publish.assert_not_awaited()
+        self.db.commit.assert_not_awaited()


### PR DESCRIPTION
## Summary

- return `409 Conflict` before deleting an embedding referenced by a RAG collection
- preserve the existing `204 No Content` path for unreferenced embeddings
- add repository and route regression coverage for the dependency check and side effects

## Rationale

`RagCollection.embedding_id` uses `ON DELETE RESTRICT`, so deleting a referenced embedding currently reaches the database and surfaces an unhandled foreign-key error. The explicit dependency check keeps that data-integrity policy, avoids poisoning the SQLAlchemy transaction with an expected constraint failure, and gives the client an actionable response. It does not translate unrelated `IntegrityError` exceptions into `409` responses.

## Validation

- `uv run --frozen ruff check giga_agent/models/rag.py giga_agent/routes/embeddings.py tests/models/test_rag_collections_repository.py tests/routes/test_embeddings_router.py`
- `uv run --frozen ruff format --check giga_agent/models/rag.py giga_agent/routes/embeddings.py tests/models/test_rag_collections_repository.py tests/routes/test_embeddings_router.py`
- `uv run --frozen pytest tests/routes/test_embeddings_router.py tests/models/test_rag_collections_repository.py` (`21 passed`)

Closes #86
